### PR TITLE
PRC-52: Add basic create contact API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEntity.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "contact")
+data class ContactEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val contactId: Long,
+
+  @Column(name = "title")
+  val title: String?,
+
+  @Column(name = "first_name")
+  val firstName: String,
+
+  @Column(name = "last_name")
+  val lastName: String,
+
+  @Column(name = "middle_name")
+  val middleName: String?,
+
+  @Column(name = "date_of_birth")
+  val dateOfBirth: LocalDate?,
+
+  @Column(updatable = false, name = "created_by")
+  val createdBy: String,
+
+  @Column(updatable = false, name = "created_time")
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+) {
+
+  companion object {
+    fun newContact(
+      title: String?,
+      firstName: String,
+      lastName: String,
+      middleName: String?,
+      dateOfBirth: LocalDate?,
+      createdBy: String,
+    ): ContactEntity {
+      return ContactEntity(
+        0,
+        title,
+        firstName,
+        lastName,
+        middleName,
+        dateOfBirth,
+        createdBy,
+        LocalDateTime.now(),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/CreateContactRequest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "Request to create a new contact")
+data class CreateContactRequest(
+
+  @Schema(description = "The title of the contact, if any", example = "Mr", nullable = true)
+  val title: String? = null,
+
+  @Schema(description = "The last name of the contact", example = "Doe")
+  val lastName: String,
+
+  @Schema(description = "The first name of the contact", example = "John")
+  val firstName: String,
+
+  @Schema(description = "The middle name of the contact, if any", example = "William", nullable = true)
+  val middleName: String? = null,
+
+  @Schema(description = "The date of birth of the contact, if known", example = "1980-01-01", nullable = true)
+  val dateOfBirth: LocalDate? = null,
+
+  @Schema(description = "The id of the user creating the contact", example = "JD000001")
+  val createdBy: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
+
+@Repository
+interface ContactRepository : JpaRepository<ContactEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+
+@Tag(name = "Contacts")
+@RestController
+@RequestMapping(value = ["contact"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class ContactController(val contactService: ContactService) {
+
+  @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    summary = "Create a new contact",
+    description = "Creates a new contact that is not yet associated with any prisoner.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "201", description = "Created the contact successfully"),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The request has invalid or missing fields",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN')")
+  fun createContact(@Valid @RequestBody createContactRequest: CreateContactRequest): ResponseEntity<Any> {
+    contactService.createContact(createContactRequest)
+    return ResponseEntity.status(HttpStatus.CREATED).build()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactsController.kt
@@ -13,9 +13,9 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @Tag(name = "Prisoner Contacts Controller")
 @RestController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -1,15 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import jakarta.persistence.EntityNotFoundException
+import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity.Companion.newContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.PrisonerContactSummary
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
 
 @Service
 class ContactService(
   private val prisonerContactRepository: PrisonerContactRepository,
+  private val contactRepository: ContactRepository,
   private val prisonerService: PrisonerService,
 ) {
   companion object {
@@ -25,5 +30,19 @@ class ContactService(
     val contacts = prisonerContactRepository.findPrisonerContacts(prisonerNumber, active).toModel()
     logger.info("Found {} contacts", contacts.size)
     return contacts
+  }
+
+  @Transactional
+  fun createContact(request: CreateContactRequest) {
+    contactRepository.saveAndFlush(
+      newContact(
+        title = request.title,
+        lastName = request.lastName,
+        firstName = request.firstName,
+        middleName = request.middleName,
+        dateOfBirth = request.dateOfBirth,
+        createdBy = request.createdBy,
+      ),
+    )
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,9 +15,6 @@ spring:
 
   jpa:
     open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: false
     generate-ddl: false
     hibernate:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/ContactEntityControllerResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/ContactEntityControllerResourceIntegrationTest.kt
@@ -1,0 +1,130 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+import java.time.LocalDate
+
+class ContactEntityControllerResourceIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var contactRepository: ContactRepository
+
+  @Nested
+  inner class Create {
+    @Test
+    fun `should return unauthorized if no token`() {
+      webTestClient.post()
+        .uri("/contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(aMinimalCreateContactRequest())
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      webTestClient.post()
+        .uri("/contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(aMinimalCreateContactRequest())
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden if wrong role`() {
+      webTestClient.post()
+        .uri("/contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(aMinimalCreateContactRequest())
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return bad request if required fields are null`() {
+      webTestClient.post()
+        .uri("/contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+    }
+
+    @Test
+    fun `should create the contact with minimal fields`() {
+      val request = aMinimalCreateContactRequest()
+
+      webTestClient.post()
+        .uri("/contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isCreated
+
+      assertThatContactIsCreated(request)
+    }
+
+    @Test
+    fun `should create the contact with all fields`() {
+      val request = CreateContactRequest(
+        title = "mr",
+        lastName = "last",
+        firstName = "first",
+        middleName = "middle",
+        dateOfBirth = LocalDate.of(1982, 6, 15),
+        createdBy = "created",
+      )
+
+      webTestClient.post()
+        .uri("/contact")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isCreated
+
+      assertThatContactIsCreated(request)
+    }
+
+    private fun assertThatContactIsCreated(request: CreateContactRequest) {
+      with(contactRepository.findAll().maxBy(ContactEntity::contactId)) {
+        assertThat(title).isEqualTo(request.title)
+        assertThat(lastName).isEqualTo(request.lastName)
+        assertThat(firstName).isEqualTo(request.firstName)
+        assertThat(middleName).isEqualTo(request.middleName)
+        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+      }
+    }
+
+    private fun aMinimalCreateContactRequest() = CreateContactRequest(
+      lastName = "last",
+      firstName = "first",
+      createdBy = "created",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
+
+class ContactControllerTest {
+
+  private val contactService: ContactService = mock()
+  private val controller = ContactController(contactService)
+
+  @Nested
+  inner class CreateContact {
+    @Test
+    fun `should create a contact successfully`() {
+      val request = CreateContactRequest(
+        lastName = "last",
+        firstName = "first",
+        createdBy = "created",
+      )
+
+      val response = controller.createContact(request)
+
+      assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+      verify(contactService).createContact(request)
+    }
+
+    @Test
+    fun `should propagate exceptions creating a contact`() {
+      val request = CreateContactRequest(
+        lastName = "last",
+        firstName = "first",
+        createdBy = "created",
+      )
+      whenever(contactService.createContact(request)).thenThrow(RuntimeException("Bang!"))
+
+      assertThrows<RuntimeException>("Bang!") {
+        controller.createContact(request)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import java.time.LocalDate
+
+class ContactServiceTest {
+
+  private val contactRepository: ContactRepository = mock()
+  private val prisonerContactRepository: PrisonerContactRepository = mock()
+  private val prisonerService: PrisonerService = mock()
+  private val service = ContactService(prisonerContactRepository, contactRepository, prisonerService)
+
+  @Nested
+  inner class CreateContact {
+    @Test
+    fun `should create a contact successfully`() {
+      val request = CreateContactRequest(
+        title = "mr",
+        lastName = "last",
+        firstName = "first",
+        middleName = "middle",
+        dateOfBirth = LocalDate.of(1982, 6, 15),
+        createdBy = "created",
+      )
+
+      service.createContact(request)
+
+      val contactCaptor = argumentCaptor<ContactEntity>()
+      verify(contactRepository).saveAndFlush(contactCaptor.capture())
+      with(contactCaptor.firstValue) {
+        assertThat(title).isEqualTo(request.title)
+        assertThat(lastName).isEqualTo(request.lastName)
+        assertThat(firstName).isEqualTo(request.firstName)
+        assertThat(middleName).isEqualTo(request.middleName)
+        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+        assertThat(createdTime).isNotNull()
+      }
+    }
+
+    @Test
+    fun `should propagate exceptions creating a contact`() {
+      val request = CreateContactRequest(
+        lastName = "last",
+        firstName = "first",
+        createdBy = "created",
+      )
+      whenever(contactRepository.saveAndFlush(any())).thenThrow(RuntimeException("Bang!"))
+
+      assertThrows<RuntimeException>("Bang!") {
+        service.createContact(request)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactEntityControllerSummaryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactEntityControllerSummaryServiceTest.kt
@@ -15,17 +15,21 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.isBool
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
 import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)
-class PrisonerContactSummaryServiceTest {
+class PrisonerContactEntityControllerSummaryServiceTest {
 
   @Mock
   private lateinit var prisonerContactRepository: PrisonerContactRepository
 
   @Mock
   private lateinit var prisonerService: PrisonerService
+
+  @Mock
+  private lateinit var contactRepository: ContactRepository
 
   @InjectMocks
   private lateinit var contactService: ContactService

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ spring:
     password: dummy
 
   flyway:
-    locations: classpath:/migrations/common
+    locations: classpath:/migrations/common,classpath:/migrations/test
 
   h2:
     console:

--- a/src/test/resources/migrations/test/V2024.08.02.3__reset_identities_for_baseline_data_on_h2.sql
+++ b/src/test/resources/migrations/test/V2024.08.02.3__reset_identities_for_baseline_data_on_h2.sql
@@ -1,0 +1,15 @@
+alter table contact alter column contact_id restart with 4;
+
+alter table contact_address alter column contact_address_id restart with 4;
+
+alter table contact_email alter column contact_email_id restart with 4;
+
+alter table contact_identity alter column contact_identity_id restart with 4;
+
+alter table contact_nationality alter column contact_nationality_id restart with 4;
+
+alter table contact_phone alter column contact_phone_id restart with 4;
+
+alter table reference_codes alter column reference_code_id restart with 34;
+
+alter table prisoner_contact alter column prisoner_contact_id restart with 2;


### PR DESCRIPTION
The most basic create contact API endpoint to get us going for now. Currently has no validation which will be added in subsequent PR.