### PR TITLE
PRC-52: Integrate get contact with create contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -18,12 +18,14 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Priso
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.PrisonNumberDoc
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @Tag(name = "Prisoner")
 @RestController
 @RequestMapping(value = ["prisoner"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@AuthApiResponses
 class PrisonerController(
   private val prisonerService: PrisonerService,
   private val prisonerContactService: PrisonerContactService,
@@ -39,26 +41,6 @@ class PrisonerController(
           Content(
             mediaType = "application/json",
             schema = Schema(implementation = PrisonerContactSummary::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorised, requires a valid Oauth2 token",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Forbidden, requires an appropriate role",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
           ),
         ],
       ),
@@ -80,26 +62,6 @@ class PrisonerController(
           Content(
             mediaType = "application/json",
             schema = Schema(implementation = PrisonerContactSummary::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorised, requires a valid Oauth2 token",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Forbidden, requires an appropriate role",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity.Companion.newContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
@@ -18,7 +19,7 @@ class ContactService(
   }
 
   @Transactional
-  fun createContact(request: CreateContactRequest) {
+  fun createContact(request: CreateContactRequest): Contact {
     val newContact = newContact(
       title = request.title,
       lastName = request.lastName,
@@ -27,23 +28,23 @@ class ContactService(
       dateOfBirth = request.dateOfBirth,
       createdBy = request.createdBy,
     )
-    contactRepository.saveAndFlush(newContact)
+    return mapEntityToContact(contactRepository.saveAndFlush(newContact))
       .also { logger.info("Created new contact {}", newContact) }
   }
 
   fun getContact(id: Long): Contact? {
     return contactRepository.findById(id).getOrNull()
-      ?.let { entity ->
-        Contact(
-          id = entity.contactId,
-          title = entity.title,
-          lastName = entity.lastName,
-          firstName = entity.firstName,
-          middleName = entity.middleName,
-          dateOfBirth = entity.dateOfBirth,
-          createdBy = entity.createdBy,
-          createdTime = entity.createdTime,
-        )
-      }
+      ?.let { entity -> mapEntityToContact(entity) }
   }
+
+  private fun mapEntityToContact(entity: ContactEntity) = Contact(
+    id = entity.contactId,
+    title = entity.title,
+    lastName = entity.lastName,
+    firstName = entity.firstName,
+    middleName = entity.middleName,
+    dateOfBirth = entity.dateOfBirth,
+    createdBy = entity.createdBy,
+    createdTime = entity.createdTime,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/swagger/AuthApiResponses.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/swagger/AuthApiResponses.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger
+
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+
+@ApiResponses(
+  value = [
+    ApiResponse(
+      responseCode = "401",
+      description = "Unauthorised, requires a valid Oauth2 token",
+      content = [
+        Content(
+          mediaType = "application/json",
+          schema = Schema(implementation = ErrorResponse::class),
+        ),
+      ],
+    ),
+    ApiResponse(
+      responseCode = "403",
+      description = "Forbidden, requires an appropriate role",
+      content = [
+        Content(
+          mediaType = "application/json",
+          schema = Schema(implementation = ErrorResponse::class),
+        ),
+      ],
+    ),
+  ],
+)
+annotation class AuthApiResponses

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -7,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.TestAPIClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.wiremock.PrisonerSearchApiExtension
@@ -24,11 +26,18 @@ abstract class IntegrationTestBase {
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
 
+  protected lateinit var testAPIClient: TestAPIClient
+
+  @BeforeEach
+  fun setupTestApiClient() {
+    testAPIClient = TestAPIClient(webTestClient, jwtAuthHelper)
+  }
+
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",
     roles: List<String> = listOf(),
     scopes: List<String> = listOf("read"),
-  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisationHeader(username = username, scope = scopes, roles = roles)
+  ): (HttpHeaders) -> Unit = testAPIClient.setAuthorisation(username = username, scopes = scopes, roles = roles)
 
   protected fun stubPingWithResponse(status: Int) {
     hmppsAuth.stubHealthPing(status)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
+import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
+
+class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAuthHelper: JwtAuthorisationHelper) {
+
+  fun createAContact(request: CreateContactRequest): Contact {
+    return webTestClient.post()
+      .uri("/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(authorised())
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isCreated
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().valuesMatch("Location", "/contact/(\\d)+")
+      .expectBody(Contact::class.java)
+      .returnResult().responseBody!!
+  }
+
+  fun getContact(id: Long): Contact {
+    return webTestClient.get()
+      .uri("/contact/$id")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(Contact::class.java)
+      .returnResult().responseBody!!
+  }
+
+  fun setAuthorisation(
+    username: String? = "AUTH_ADM",
+    roles: List<String> = listOf(),
+    scopes: List<String> = listOf("read"),
+  ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisationHeader(username = username, scope = scopes, roles = roles)
+
+  private fun authorised() = setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN"))
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -2,17 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import java.time.LocalDate
 
 class GetContactByIdIntegrationTest : IntegrationTestBase() {
-
-  @Autowired
-  private lateinit var contactRepository: ContactRepository
 
   @Test
   fun `should return unauthorized if no token`() {
@@ -58,16 +52,7 @@ class GetContactByIdIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `should get the contact with all fields`() {
-    val contact = webTestClient.get()
-      .uri("/contact/1")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(Contact::class.java)
-      .returnResult().responseBody!!
+    val contact = testAPIClient.getContact(1)
 
     with(contact) {
       assertThat(id).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
+import java.net.URI
 import java.time.LocalDateTime
 
 class ContactControllerTest {
@@ -27,10 +28,20 @@ class ContactControllerTest {
         firstName = "first",
         createdBy = "created",
       )
+      val expectedContact = Contact(
+        id = 99,
+        lastName = request.lastName,
+        firstName = request.firstName,
+        createdBy = request.createdBy,
+        createdTime = LocalDateTime.now(),
+      )
+      whenever(contactService.createContact(request)).thenReturn(expectedContact)
 
       val response = controller.createContact(request)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
+      assertThat(response.body).isEqualTo(expectedContact)
+      assertThat(response.headers.location).isEqualTo(URI.create("/contact/99"))
       verify(contactService).createContact(request)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -35,12 +35,22 @@ class ContactServiceTest {
         dateOfBirth = LocalDate.of(1982, 6, 15),
         createdBy = "created",
       )
+      whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
 
-      service.createContact(request)
+      val createdContact = service.createContact(request)
 
       val contactCaptor = argumentCaptor<ContactEntity>()
       verify(contactRepository).saveAndFlush(contactCaptor.capture())
       with(contactCaptor.firstValue) {
+        assertThat(title).isEqualTo(request.title)
+        assertThat(lastName).isEqualTo(request.lastName)
+        assertThat(firstName).isEqualTo(request.firstName)
+        assertThat(middleName).isEqualTo(request.middleName)
+        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+        assertThat(createdTime).isNotNull()
+      }
+      with(createdContact) {
         assertThat(title).isEqualTo(request.title)
         assertThat(lastName).isEqualTo(request.lastName)
         assertThat(firstName).isEqualTo(request.firstName)


### PR DESCRIPTION
Create now returns the created contact as well a Location header. The tests now use get instead of the repository directly. Also, some minor swagger tidying for common responses.
Also also, I created a test API client so we can put common methods we're going to use across other integration tests, e.g., creating and getting a contact.