### PR TITLE
PRC-52: Add validation to create contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
@@ -1,26 +1,34 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 
 @Schema(description = "Request to create a new contact")
 data class CreateContactRequest(
 
-  @Schema(description = "The title of the contact, if any", example = "Mr", nullable = true)
+  @Schema(description = "The title of the contact, if any", example = "Mr", nullable = true, maxLength = 12)
+  @field:Size(max = 12, message = "title must be <= 12 characters")
   val title: String? = null,
 
-  @Schema(description = "The last name of the contact", example = "Doe")
+  @Schema(description = "The last name of the contact", example = "Doe", maxLength = 35)
+  @field:Size(max = 35, message = "lastName must be <= 35 characters")
   val lastName: String,
 
-  @Schema(description = "The first name of the contact", example = "John")
+  @Schema(description = "The first name of the contact", example = "John", maxLength = 35)
+  @field:Size(max = 35, message = "firstName must be <= 35 characters")
   val firstName: String,
 
-  @Schema(description = "The middle name of the contact, if any", example = "William", nullable = true)
+  @Schema(description = "The middle name of the contact, if any", example = "William", nullable = true, maxLength = 35)
+  @field:Size(max = 35, message = "middleName must be <= 35 characters")
   val middleName: String? = null,
 
-  @Schema(description = "The date of birth of the contact, if known", example = "1980-01-01", nullable = true)
+  @Schema(description = "The date of birth of the contact, if known", example = "1980-01-01", nullable = true, format = "yyyy-MM-dd")
+  @field:DateTimeFormat(pattern = "yyyy-MM-dd")
   val dateOfBirth: LocalDate? = null,
 
-  @Schema(description = "The id of the user creating the contact", example = "JD000001")
+  @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)
+  @field:Size(max = 100, message = "createdBy must be <= 100 characters")
   val createdBy: String,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -2,7 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
@@ -48,17 +53,77 @@ class CreateContactIntegrationTest : IntegrationTestBase() {
       .isForbidden
   }
 
-  @Test
-  fun `should return bad request if required fields are null`() {
-    webTestClient.post()
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "firstName must not be null;{\"firstName\": null, \"lastName\": \"last\", \"createdBy\": \"created\"}",
+      "firstName must not be null;{\"lastName\": \"last\", \"createdBy\": \"created\"}",
+      "lastName must not be null;{\"firstName\": \"first\", \"lastName\": null, \"createdBy\": \"created\"}",
+      "lastName must not be null;{\"firstName\": \"first\", \"createdBy\": \"created\"}",
+      "createdBy must not be null;{\"firstName\": \"first\", \"lastName\": \"last\", \"createdBy\": null}",
+      "createdBy must not be null;{\"firstName\": \"first\", \"lastName\": \"last\"}",
+    ],
+    delimiter = ';',
+  )
+  fun `should return bad request if required fields are null`(expectedMessage: String, json: String) {
+    val errors = webTestClient.post()
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .bodyValue("{}")
+      .bodyValue(json)
       .exchange()
       .expectStatus()
       .isBadRequest
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Validation failure: $expectedMessage")
+  }
+
+  @ParameterizedTest
+  @MethodSource("allFieldConstraintViolations")
+  fun `should enforce field constraints`(expectedMessage: String, request: CreateContactRequest) {
+    val errors = webTestClient.post()
+      .uri("/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Validation failure(s): $expectedMessage")
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "{\"firstName\": \"first\", \"lastName\": \"last\", \"createdBy\": \"created\", \"dateOfBirth\": \"1st Jan\"}",
+      "{\"firstName\": \"first\", \"lastName\": \"last\", \"createdBy\": \"created\", \"dateOfBirth\": \"01-01-1970\"}",
+    ],
+    delimiter = ';',
+  )
+  fun `should handle invalid dob formats`(json: String) {
+    val errors = webTestClient.post()
+      .uri("/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(json)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Validation failure: dateOfBirth could not be parsed as a date")
   }
 
   @Test
@@ -98,9 +163,34 @@ class CreateContactIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  private fun aMinimalCreateContactRequest() = CreateContactRequest(
-    lastName = "last",
-    firstName = "first",
-    createdBy = "created",
-  )
+  companion object {
+    @JvmStatic
+    fun allFieldConstraintViolations(): List<Arguments> {
+      return listOf(
+        Arguments.of("title must be <= 12 characters", aMinimalCreateContactRequest().copy(title = "".padStart(13))),
+        Arguments.of(
+          "lastName must be <= 35 characters",
+          aMinimalCreateContactRequest().copy(lastName = "".padStart(36)),
+        ),
+        Arguments.of(
+          "firstName must be <= 35 characters",
+          aMinimalCreateContactRequest().copy(firstName = "".padStart(36)),
+        ),
+        Arguments.of(
+          "middleName must be <= 35 characters",
+          aMinimalCreateContactRequest().copy(middleName = "".padStart(36)),
+        ),
+        Arguments.of(
+          "createdBy must be <= 100 characters",
+          aMinimalCreateContactRequest().copy(createdBy = "".padStart(101)),
+        ),
+      )
+    }
+
+    private fun aMinimalCreateContactRequest() = CreateContactRequest(
+      lastName = "last",
+      firstName = "first",
+      createdBy = "created",
+    )
+  }
 }


### PR DESCRIPTION
Added field length constraints with custom error messages to 1) be helpful to client and 2) stop exposing SQL error messages if the fields are too long.