### PR TITLE
PRC-55: Add contact relationship to create contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactEntity.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "prisoner_contact")
+data class PrisonerContactEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val prisonerContactId: Long,
+
+  @Column(name = "contact_id")
+  val contactId: Long,
+
+  @Column(name = "prisoner_number")
+  val prisonerNumber: String,
+
+  @Column(name = "relationship_type")
+  val relationshipType: String,
+
+  @Column(name = "next_of_kin")
+  val nextOfKin: Boolean,
+
+  @Column(name = "emergency_contact")
+  val emergencyContact: Boolean,
+
+  @Column(name = "comments")
+  val comments: String?,
+
+  @Column(updatable = false, name = "created_by")
+  val createdBy: String,
+
+  @Column(updatable = false, name = "created_time")
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+) {
+
+  companion object {
+    fun newPrisonerContact(
+      contactId: Long,
+      prisonerNumber: String,
+      relationshipType: String,
+      nextOfKin: Boolean,
+      emergencyContact: Boolean,
+      comments: String?,
+      createdBy: String,
+    ): PrisonerContactEntity {
+      return PrisonerContactEntity(
+        0,
+        contactId,
+        prisonerNumber,
+        relationshipType,
+        nextOfKin,
+        emergencyContact,
+        comments,
+        createdBy,
+        LocalDateTime.now(),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/PrisonerContactMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/PrisonerContactMappers.kt
@@ -29,7 +29,7 @@ fun PrisonerContactSummaryEntity.toModel(): PrisonerContactSummary {
     nextOfKin = this.nextOfKin,
     emergencyContact = this.emergencyContact,
     awareOfCharges = this.awareOfCharges,
-    comments = this.comments ?: "",
+    comments = this.comments,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactRelationshipRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/ContactRelationshipRequest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ContactRelationshipRequest(
+
+  @Schema(description = "Prisoner number (NOMS ID)", example = "A1234BC")
+  val prisonerNumber: String,
+
+  @Schema(description = "The relationship code between the prisoner and the contact", example = "FRI")
+  val relationshipCode: String,
+
+  @Schema(description = "Whether they are the next of kin for the prisoner", example = "true", required = true)
+  @JsonProperty(required = true)
+  val isNextOfKin: Boolean,
+
+  @Schema(description = "Whether they are the emergency contact for the prisoner", example = "true", required = true)
+  @JsonProperty(required = true)
+  val isEmergencyContact: Boolean,
+
+  @Schema(description = "Comments about the contacts relationship with the prisoner", example = "Some additional information", nullable = true)
+  val comments: String? = null,
+
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
@@ -31,6 +31,9 @@ data class CreateContactRequest(
   @Schema(description = "If the date of birth is not known, this indicates whether they are believed to be over 18 or not", example = "YES", nullable = true)
   val isOverEighteen: IsOverEighteen? = null,
 
+  @Schema(description = "A description of the relationship if the contact should be linked to a prisoner", nullable = true, exampleClasses = [ContactRelationshipRequest::class])
+  val relationship: ContactRelationshipRequest? = null,
+
   @Schema(description = "The id of the user creating the contact", example = "JD000001", maxLength = 100)
   @field:Size(max = 100, message = "createdBy must be <= 100 characters")
   val createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
@@ -1,18 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
-import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
 
 @Repository
-interface PrisonerContactRepository : ReadOnlyRepository<PrisonerContactSummaryEntity, Long> {
-
-  @Query(
-    value = """
-      FROM PrisonerContactSummaryEntity pcs
-      WHERE pcs.prisonerNumber = :prisonerNumber
-      AND pcs.active = :activeFlag
-    """,
-  )
-  fun findPrisonerContacts(prisonerNumber: String, activeFlag: Boolean = true): List<PrisonerContactSummaryEntity>
-}
+interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactSummaryRepository.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
+
+@Repository
+interface PrisonerContactSummaryRepository : ReadOnlyRepository<PrisonerContactSummaryEntity, Long> {
+
+  @Query(
+    value = """
+      FROM PrisonerContactSummaryEntity pcs
+      WHERE pcs.prisonerNumber = :prisonerNumber
+      AND pcs.active = :activeFlag
+    """,
+  )
+  fun findPrisonerContacts(prisonerNumber: String, activeFlag: Boolean = true): List<PrisonerContactSummaryEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -58,6 +58,11 @@ class ContactController(val contactService: ContactService) {
         description = "The request has invalid or missing fields",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],
       ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Could not find the prisoner that this contact has a relationship to",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
+import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity.Companion.newContact
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity.Companion.newPrisonerContact
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
 import java.time.Clock
 import java.time.LocalDate
 import kotlin.jvm.optionals.getOrNull
@@ -16,6 +20,8 @@ import kotlin.jvm.optionals.getOrNull
 @Service
 class ContactService(
   private val contactRepository: ContactRepository,
+  private val prisonerContactRepository: PrisonerContactRepository,
+  private val prisonerService: PrisonerService,
   private val clock: Clock,
 ) {
   companion object {
@@ -24,22 +30,27 @@ class ContactService(
 
   @Transactional
   fun createContact(request: CreateContactRequest): Contact {
-    val newContact = newContact(
-      title = request.title,
-      lastName = request.lastName,
-      firstName = request.firstName,
-      middleName = request.middleName,
-      dateOfBirth = request.dateOfBirth,
-      isOverEighteen = mapIsOverEighteen(request),
-      createdBy = request.createdBy,
-    )
-    return mapEntityToContact(contactRepository.saveAndFlush(newContact))
-      .also { logger.info("Created new contact {}", newContact) }
+    validate(request)
+    val newContact = mapContact(request)
+    val createdContact = mapEntityToContact(contactRepository.saveAndFlush(newContact))
+    val newRelationship = request.relationship
+      ?.let { mapRelationShip(createdContact, request.relationship, request) }
+      ?.let { prisonerContactRepository.saveAndFlush(it) }
+
+    logger.info("Created new contact {}", createdContact)
+    newRelationship?.let { logger.info("Created new relationship {}", newRelationship) }
+    return createdContact
   }
 
   fun getContact(id: Long): Contact? {
     return contactRepository.findById(id).getOrNull()
       ?.let { entity -> mapEntityToContact(entity) }
+  }
+
+  private fun validate(request: CreateContactRequest) {
+    if (request.relationship != null) {
+      prisonerService.getPrisoner(request.relationship.prisonerNumber) ?: throw EntityNotFoundException("Prisoner number ${request.relationship.prisonerNumber} - not found")
+    }
   }
 
   private fun mapEntityToContact(entity: ContactEntity) = Contact(
@@ -53,6 +64,31 @@ class ContactService(
     createdBy = entity.createdBy,
     createdTime = entity.createdTime,
   )
+
+  private fun mapRelationShip(
+    createdContact: Contact,
+    relationship: ContactRelationshipRequest,
+    request: CreateContactRequest,
+  ) = newPrisonerContact(
+    createdContact.id,
+    relationship.prisonerNumber,
+    relationship.relationshipCode,
+    relationship.isNextOfKin,
+    relationship.isEmergencyContact,
+    relationship.comments,
+    request.createdBy,
+  )
+
+  private fun mapContact(request: CreateContactRequest) =
+    newContact(
+      title = request.title,
+      lastName = request.lastName,
+      firstName = request.firstName,
+      middleName = request.middleName,
+      dateOfBirth = request.dateOfBirth,
+      isOverEighteen = mapIsOverEighteen(request),
+      createdBy = request.createdBy,
+    )
 
   private fun mapIsOverEighteen(entity: ContactEntity): IsOverEighteen {
     return if (entity.dateOfBirth != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactService.kt
@@ -4,16 +4,16 @@ import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactSummaryRepository
 
 @Service
 class PrisonerContactService(
-  private val prisonerContactRepository: PrisonerContactRepository,
+  private val prisonerContactSummaryRepository: PrisonerContactSummaryRepository,
   private val prisonerService: PrisonerService,
 ) {
   fun getAllContacts(prisonerNumber: String, active: Boolean): List<PrisonerContactSummary> {
     prisonerService.getPrisoner(prisonerNumber)
       ?: throw EntityNotFoundException("Prisoner number $prisonerNumber - not found")
-    return prisonerContactRepository.findPrisonerContacts(prisonerNumber, active).toModel()
+    return prisonerContactSummaryRepository.findPrisonerContacts(prisonerNumber, active).toModel()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -5,6 +5,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
 class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAuthHelper: JwtAuthorisationHelper) {
@@ -37,6 +38,16 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .expectBody(Contact::class.java)
       .returnResult().responseBody!!
   }
+
+  fun getPrisonerContacts(prisonerNumber: String): List<PrisonerContactSummary> = webTestClient.get()
+    .uri("/prisoner/$prisonerNumber/contact")
+    .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+    .exchange()
+    .expectStatus()
+    .isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBodyList(PrisonerContactSummary::class.java)
+    .returnResult().responseBody!!
 
   fun setAuthorisation(
     username: String? = "AUTH_ADM",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -1,0 +1,145 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.apache.commons.lang3.RandomStringUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationshipRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
+
+class CreateContactWithRelationshipIntegrationTest : IntegrationTestBase() {
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "relationship.prisonerNumber must not be null;{ \"relationshipCode\": \"FRI\", \"isNextOfKin\": false, \"isEmergencyContact\": false }",
+      "relationship.relationshipCode must not be null;{ \"prisonerNumber\": \"A1234BC\", \"isNextOfKin\": false, \"isEmergencyContact\": false }",
+      "relationship.isNextOfKin is invalid;{ \"prisonerNumber\": \"A1234BC\", \"relationshipCode\": \"FRI\", \"isEmergencyContact\": false }",
+      "relationship.isEmergencyContact is invalid;{ \"prisonerNumber\": \"A1234BC\", \"relationshipCode\": \"FRI\", \"isNextOfKin\": false }",
+    ],
+    delimiter = ';',
+  )
+  fun `should return bad request if required fields are null`(expectedMessage: String, relationShipJson: String) {
+    val json =
+      "{\"firstName\": \"first\", \"lastName\": \"last\", \"createdBy\": \"created\", \"relationship\": $relationShipJson}"
+    val errors = webTestClient.post()
+      .uri("/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(json)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Validation failure: $expectedMessage")
+  }
+
+  @Test
+  fun `should return a 404 if the prisoner can not be found`() {
+    val prisonerNumber = "A1234AB"
+    stubPrisonSearchWithNotFoundResponse(prisonerNumber)
+    val request = CreateContactRequest(
+      lastName = RandomStringUtils.random(35),
+      firstName = "a new guy",
+      createdBy = "created",
+      relationship = ContactRelationshipRequest(
+        prisonerNumber = prisonerNumber,
+        relationshipCode = "FRI",
+        isNextOfKin = false,
+        isEmergencyContact = false,
+        comments = null,
+      ),
+    )
+
+    val errors = webTestClient.post()
+      .uri("/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Entity not found : Prisoner number A1234AB - not found")
+  }
+
+  @Test
+  fun `should create the contact relationship with minimal fields`() {
+    val prisonerNumber = "A1234AB"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    val requestedRelationship = ContactRelationshipRequest(
+      prisonerNumber = prisonerNumber,
+      relationshipCode = "FRI",
+      isNextOfKin = false,
+      isEmergencyContact = false,
+      comments = null,
+    )
+    val request = CreateContactRequest(
+      lastName = RandomStringUtils.random(35),
+      firstName = "a new guy",
+      createdBy = "created",
+      relationship = requestedRelationship,
+    )
+
+    testAPIClient.createAContact(request)
+
+    val prisonerContacts = testAPIClient.getPrisonerContacts(prisonerNumber)
+    assertThat(prisonerContacts).hasSize(1)
+
+    val prisonerContact = prisonerContacts[0]
+    assertThat(prisonerContact.surname).isEqualTo(request.lastName)
+    asserPrisonerContactEquals(prisonerContact, requestedRelationship)
+  }
+
+  @Test
+  fun `should create the contact relationship with all fields`() {
+    val prisonerNumber = "A1234AA"
+    stubPrisonSearchWithResponse(prisonerNumber)
+    val requestedRelationship = ContactRelationshipRequest(
+      prisonerNumber = prisonerNumber,
+      relationshipCode = "FRI",
+      isNextOfKin = true,
+      isEmergencyContact = true,
+      comments = "Some comments",
+    )
+    val request = CreateContactRequest(
+      lastName = RandomStringUtils.random(35),
+      firstName = "a new guy",
+      createdBy = "created",
+      relationship = requestedRelationship,
+    )
+
+    testAPIClient.createAContact(request)
+    val prisonerContacts = testAPIClient.getPrisonerContacts(prisonerNumber)
+    assertThat(prisonerContacts).hasSize(1)
+
+    val prisonerContact = prisonerContacts[0]
+    assertThat(prisonerContact.surname).isEqualTo(request.lastName)
+    asserPrisonerContactEquals(prisonerContact, requestedRelationship)
+  }
+
+  private fun asserPrisonerContactEquals(
+    prisonerContact: PrisonerContactSummary,
+    relationship: ContactRelationshipRequest,
+  ) {
+    with(prisonerContact) {
+      assertThat(relationshipCode).isEqualTo(relationship.relationshipCode)
+      assertThat(nextOfKin).isEqualTo(relationship.isNextOfKin)
+      assertThat(emergencyContact).isEqualTo(relationship.isEmergencyContact)
+      assertThat(comments).isEqualTo(relationship.comments)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchPrisonerContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SearchPrisonerContactsIntegrationTest.kt
@@ -57,7 +57,7 @@ class SearchPrisonerContactsIntegrationTest : IntegrationTestBase() {
   fun `should return OK`() {
     stubPrisonSearchWithResponse("A1234BB")
 
-    var contacts = webTestClient.getContacts(GET_PRISONER_CONTACT)
+    val contacts = webTestClient.getContacts(GET_PRISONER_CONTACT)
 
     assertThat(contacts).extracting("surname").contains("Last")
     assertThat(contacts).hasSize(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
@@ -17,14 +17,14 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.hasSize
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactSummaryRepository
 import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)
 class PrisonerContactServiceTest {
 
   @Mock
-  private lateinit var prisonerContactRepository: PrisonerContactRepository
+  private lateinit var prisonerContactSummaryRepository: PrisonerContactSummaryRepository
 
   @Mock
   private lateinit var prisonerService: PrisonerService
@@ -49,14 +49,14 @@ class PrisonerContactServiceTest {
     val contacts = listOf(c1, c2)
 
     whenever(prisonerService.getPrisoner(prisonerNumber)).thenReturn(prisoner)
-    whenever(prisonerContactRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
+    whenever(prisonerContactSummaryRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
 
     val result = prisonerContactService.getAllContacts(prisonerNumber, true)
 
     result hasSize 2
     assertThat(result).containsAll(listOf(c1.toModel(), c2.toModel()))
 
-    verify(prisonerContactRepository).findPrisonerContacts(prisonerNumber, true)
+    verify(prisonerContactSummaryRepository).findPrisonerContacts(prisonerNumber, true)
   }
 
   @Test
@@ -66,7 +66,7 @@ class PrisonerContactServiceTest {
     val contacts = listOf(c1)
 
     whenever(prisonerService.getPrisoner(prisonerNumber)).thenReturn(prisoner)
-    whenever(prisonerContactRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
+    whenever(prisonerContactSummaryRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
 
     val result = prisonerContactService.getAllContacts(prisonerNumber, true)
 
@@ -75,7 +75,7 @@ class PrisonerContactServiceTest {
       assertThat(isOverEighteen).isEqualTo(IsOverEighteen.YES)
     }
 
-    verify(prisonerContactRepository).findPrisonerContacts(prisonerNumber, true)
+    verify(prisonerContactSummaryRepository).findPrisonerContacts(prisonerNumber, true)
   }
 
   @Test
@@ -84,7 +84,7 @@ class PrisonerContactServiceTest {
     val contacts = listOf(c1)
 
     whenever(prisonerService.getPrisoner(prisonerNumber)).thenReturn(prisoner)
-    whenever(prisonerContactRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
+    whenever(prisonerContactSummaryRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
 
     val result = prisonerContactService.getAllContacts(prisonerNumber, true)
 
@@ -93,7 +93,7 @@ class PrisonerContactServiceTest {
       assertThat(isOverEighteen).isEqualTo(IsOverEighteen.YES)
     }
 
-    verify(prisonerContactRepository).findPrisonerContacts(prisonerNumber, true)
+    verify(prisonerContactSummaryRepository).findPrisonerContacts(prisonerNumber, true)
   }
 
   @Test
@@ -102,7 +102,7 @@ class PrisonerContactServiceTest {
     val contacts = listOf(c1)
 
     whenever(prisonerService.getPrisoner(prisonerNumber)).thenReturn(prisoner)
-    whenever(prisonerContactRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
+    whenever(prisonerContactSummaryRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
 
     val result = prisonerContactService.getAllContacts(prisonerNumber, true)
 
@@ -111,7 +111,7 @@ class PrisonerContactServiceTest {
       assertThat(isOverEighteen).isEqualTo(IsOverEighteen.DO_NOT_KNOW)
     }
 
-    verify(prisonerContactRepository).findPrisonerContacts(prisonerNumber, true)
+    verify(prisonerContactSummaryRepository).findPrisonerContacts(prisonerNumber, true)
   }
 
   @Test
@@ -121,7 +121,7 @@ class PrisonerContactServiceTest {
     val contacts = listOf(c1)
 
     whenever(prisonerService.getPrisoner(prisonerNumber)).thenReturn(prisoner)
-    whenever(prisonerContactRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
+    whenever(prisonerContactSummaryRepository.findPrisonerContacts(prisonerNumber, true)).thenReturn(contacts)
 
     val result = prisonerContactService.getAllContacts(prisonerNumber, true)
 
@@ -130,7 +130,7 @@ class PrisonerContactServiceTest {
       assertThat(isOverEighteen).isEqualTo(IsOverEighteen.NO)
     }
 
-    verify(prisonerContactRepository).findPrisonerContacts(prisonerNumber, true)
+    verify(prisonerContactSummaryRepository).findPrisonerContacts(prisonerNumber, true)
   }
 
   @Test


### PR DESCRIPTION
Added an optional relationship to the create contact request. This populates the prisoner_contact table and the contact will then be returned from the /prisoner/A1234BC/contact endpoint.