### PR TITLE
PRC-144 : Update isOverEighteen to estimatedIsOverEighteen fore more clarity and clean up logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEntity.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
-import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -17,28 +19,21 @@ data class ContactEntity(
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val contactId: Long,
 
-  @Column(name = "title")
   val title: String?,
 
-  @Column(name = "first_name")
   val firstName: String,
 
-  @Column(name = "last_name")
   val lastName: String,
 
-  @Column(name = "middle_name")
   val middleName: String?,
 
-  @Column(name = "date_of_birth")
   val dateOfBirth: LocalDate?,
 
-  @Column(name = "is_over_eighteen")
-  val isOverEighteen: Boolean?,
+  @Enumerated(EnumType.STRING)
+  val estimatedIsOverEighteen: EstimatedIsOverEighteen,
 
-  @Column(updatable = false, name = "created_by")
   val createdBy: String,
 
-  @Column(updatable = false, name = "created_time")
   @CreationTimestamp
   val createdTime: LocalDateTime,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactSummaryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/PrisonerContactSummaryEntity.kt
@@ -1,9 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.springframework.data.annotation.Immutable
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import java.time.LocalDate
 
 @Entity
@@ -25,7 +28,8 @@ data class PrisonerContactSummaryEntity(
 
   val dateOfBirth: LocalDate?,
 
-  val isOverEighteen: Boolean?,
+  @Enumerated(EnumType.STRING)
+  val estimatedIsOverEighteen: EstimatedIsOverEighteen,
 
   val contactAddressId: Long?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearch
 import java.time.LocalDate
@@ -20,7 +20,7 @@ fun ContactEntity.toModel() = Contact(
   firstName = this.firstName,
   middleName = this.middleName,
   dateOfBirth = this.dateOfBirth,
-  isOverEighteen = mapIsOverEighteen(this),
+  estimatedIsOverEighteen = this.estimatedIsOverEighteen,
   createdBy = this.createdBy,
   createdTime = this.createdTime,
 )
@@ -77,40 +77,9 @@ fun CreateContactRequest.toModel() =
     firstName = this.firstName,
     middleName = this.middleName,
     dateOfBirth = this.dateOfBirth,
-    isOverEighteen = mapIsOverEighteen(this),
+    estimatedIsOverEighteen = this.estimatedIsOverEighteen!!,
     createdBy = this.createdBy,
   )
-
-private fun mapIsOverEighteen(entity: ContactEntity): IsOverEighteen {
-  return if (entity.dateOfBirth != null) {
-    if (isOver18(entity.dateOfBirth)) {
-      IsOverEighteen.YES
-    } else {
-      IsOverEighteen.NO
-    }
-  } else {
-    when (entity.isOverEighteen) {
-      true -> IsOverEighteen.YES
-      false -> IsOverEighteen.NO
-      null -> IsOverEighteen.DO_NOT_KNOW
-    }
-  }
-}
-
-private fun isOver18(dateOfBirth: LocalDate) = !dateOfBirth.isAfter(LocalDate.now().minusYears(18))
-
-private fun mapIsOverEighteen(request: CreateContactRequest): Boolean? {
-  return if (request.dateOfBirth != null) {
-    null
-  } else {
-    when (request.isOverEighteen) {
-      IsOverEighteen.YES -> true
-      IsOverEighteen.NO -> false
-      IsOverEighteen.DO_NOT_KNOW -> null
-      null -> null
-    }
-  }
-}
 
 private fun newContact(
   title: String?,
@@ -118,7 +87,7 @@ private fun newContact(
   lastName: String,
   middleName: String?,
   dateOfBirth: LocalDate?,
-  isOverEighteen: Boolean?,
+  estimatedIsOverEighteen: EstimatedIsOverEighteen,
   createdBy: String,
 ): ContactEntity {
   return ContactEntity(
@@ -128,7 +97,7 @@ private fun newContact(
     lastName,
     middleName,
     dateOfBirth,
-    isOverEighteen,
+    estimatedIsOverEighteen,
     createdBy,
     LocalDateTime.now(),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/PrisonerContactMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/PrisonerContactMappers.kt
@@ -1,9 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
 
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactSummaryEntity
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
-import java.time.LocalDate
 
 fun PrisonerContactSummaryEntity.toModel(): PrisonerContactSummary {
   return PrisonerContactSummary(
@@ -14,7 +12,7 @@ fun PrisonerContactSummaryEntity.toModel(): PrisonerContactSummary {
     forename = this.firstName,
     middleName = this.middleName,
     dateOfBirth = this.dateOfBirth,
-    isOverEighteen = this.mapIsOverEighteen(),
+    estimatedIsOverEighteen = this.estimatedIsOverEighteen,
     relationshipCode = this.relationshipType,
     relationshipDescription = this.relationshipDescription ?: "",
     flat = this.flat ?: "",
@@ -34,21 +32,3 @@ fun PrisonerContactSummaryEntity.toModel(): PrisonerContactSummary {
 }
 
 fun List<PrisonerContactSummaryEntity>.toModel() = map { it.toModel() }
-
-fun PrisonerContactSummaryEntity.mapIsOverEighteen(): IsOverEighteen {
-  return if (this.dateOfBirth != null) {
-    if (!this.dateOfBirth.isAfter(LocalDate.now().minusYears(18))) {
-      IsOverEighteen.YES
-    } else {
-      IsOverEighteen.NO
-    }
-  } else {
-    when (this.isOverEighteen) {
-      true -> IsOverEighteen.YES
-      false -> IsOverEighteen.NO
-      else -> {
-        IsOverEighteen.DO_NOT_KNOW
-      }
-    }
-  }
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactRequest.kt
@@ -29,7 +29,7 @@ data class CreateContactRequest(
   val dateOfBirth: LocalDate? = null,
 
   @Schema(description = "If the date of birth is not known, this indicates whether they are believed to be over 18 or not", example = "YES", nullable = true)
-  val isOverEighteen: IsOverEighteen? = null,
+  val estimatedIsOverEighteen: EstimatedIsOverEighteen? = EstimatedIsOverEighteen.DO_NOT_KNOW,
 
   @Schema(description = "A description of the relationship if the contact should be linked to a prisoner", nullable = true, exampleClasses = [ContactRelationship::class])
   val relationship: ContactRelationship? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/EstimatedIsOverEighteen.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/EstimatedIsOverEighteen.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
 
-enum class IsOverEighteen {
+enum class EstimatedIsOverEighteen {
   YES,
   NO,
   DO_NOT_KNOW,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/Contact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/Contact.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -27,7 +27,7 @@ data class Contact(
   val dateOfBirth: LocalDate? = null,
 
   @Schema(description = "Whether the contact is over 18, based on their date of birth if it is known", example = "YES")
-  val isOverEighteen: IsOverEighteen,
+  val estimatedIsOverEighteen: EstimatedIsOverEighteen,
 
   @Schema(description = "The id of the user who created the contact", example = "JD000001")
   val createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummary.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import java.time.LocalDate
 
 @Schema(description = "Describes the details of a prisoner's contact")
@@ -29,7 +29,7 @@ data class PrisonerContactSummary(
   val dateOfBirth: LocalDate?,
 
   @Schema(description = "YES if the contact is over 18 years old, NO if under, null if unknown", example = "YES")
-  val isOverEighteen: IsOverEighteen,
+  val estimatedIsOverEighteen: EstimatedIsOverEighteen,
 
   @Schema(description = "The relationship code between the prisoner and the contact", example = "FRI")
   val relationshipCode: String,

--- a/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
@@ -13,7 +13,7 @@ AS
       c.middle_name,
       c.last_name,
       c.date_of_birth,
-      c.is_over_eighteen,
+      c.estimated_is_over_eighteen,
       ca.contact_address_id,
       ca.flat,
       ca.property,

--- a/src/main/resources/migrations/common/V2024.08.02.1__baseline_tables.sql
+++ b/src/main/resources/migrations/common/V2024.08.02.1__baseline_tables.sql
@@ -17,7 +17,7 @@ CREATE TABLE contact
     first_name varchar(35) NOT NULL,
     middle_name varchar(35),
     date_of_birth date,
-    is_over_eighteen boolean,
+    estimated_is_over_eighteen varchar(11),
     place_of_birth varchar(25),
     active boolean NOT NULL default true,
     suspended boolean NOT NULL DEFAULT false,

--- a/src/main/resources/migrations/common/V2024.08.02.2__baseline_data.sql
+++ b/src/main/resources/migrations/common/V2024.08.02.2__baseline_data.sql
@@ -2,19 +2,19 @@
 -- Reference data
 -- =============================================
 
-insert into contact(contact_id, contact_type_code, title, last_name, first_name, middle_name, date_of_birth, place_of_birth, gender, marital_status, language_code, comments, created_by, active)
-values (1, 'SOCIAL',   'MR',   'Last',   'Jack',       'Middle', '2000-11-21', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (2, 'SOCIAL',   'MISS', 'Last',   'Jacqueline', 'Middle', '2000-11-22', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (3, 'OFFICIAL', 'MRS', 'Last',    'Jane',       'Middle', '2000-11-23', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (4, 'SOCIAL',   'MR',   'Four',   'John',       'Middle', '2000-05-18', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (5, 'SOCIAL',   'MR',   'Five',   'Jon',        'Middle', '2000-09-21', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (6, 'SOCIAL',   'MR',   'Six',    'Johnny',     'Middle', '2000-10-23', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (7, 'SOCIAL',   'MR',   'Seven',  'Pete',       'Middle', '2015-08-29', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (8, 'SOCIAL',   'MR',   'Eight',  'Harry',      'Middle', '2015-12-23', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (9, 'SOCIAL',   'MR',   'Nine',   'Donald',     'Middle', '2000-11-23', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (10, 'SOCIAL',  'MS',   'Ten',    'Freya',      'Middle', '2000-11-24', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (11, 'SOCIAL',  'MS',   'Eleven', 'Suki',       'Middle', '2000-11-25', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (12, 'SOCIAL',  'MRS',  'Twelve', 'Jane',       'Middle', '2000-11-26', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false);
+insert into contact(contact_id, contact_type_code, title, last_name, first_name, middle_name, date_of_birth, estimated_is_over_eighteen, place_of_birth, gender, marital_status, language_code, comments, created_by, active)
+values (1, 'SOCIAL',   'MR',   'Last',   'Jack',       'Middle', '2000-11-21', 'DO_NOT_KNOW', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (2, 'SOCIAL',   'MISS', 'Last',   'Jacqueline', 'Middle', '2000-11-22', 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (3, 'OFFICIAL', 'MRS', 'Last',    'Jane',       'Middle', '2000-11-23', 'NO', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (4, 'SOCIAL',   'MR',   'Four',   'John',       'Middle', '2000-05-18', 'DO_NOT_KNOW', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (5, 'SOCIAL',   'MR',   'Five',   'Jon',        'Middle', '2000-09-21', 'YES', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (6, 'SOCIAL',   'MR',   'Six',    'Johnny',     'Middle', '2000-10-23', 'NO', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (7, 'SOCIAL',   'MR',   'Seven',  'Pete',       'Middle', '2015-08-29', 'YES', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (8, 'SOCIAL',   'MR',   'Eight',  'Harry',      'Middle', '2015-12-23', 'NO', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (9, 'SOCIAL',   'MR',   'Nine',   'Donald',     'Middle', '2000-11-23', 'DO_NOT_KNOW', 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (10, 'SOCIAL',  'MS',   'Ten',    'Freya',      'Middle', '2000-11-24', 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true),
+       (11, 'SOCIAL',  'MS',   'Eleven', 'Suki',       'Middle', '2000-11-25', 'NO', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
+       (12, 'SOCIAL',  'MRS',  'Twelve', 'Jane',       'Middle', '2000-11-26', 'DO_NOT_KNOW', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false);
 
 insert into contact_identity(contact_identity_id, contact_id, identity_type, identity_value, created_by)
 values (1, 1, 'DRIVING_LIC', 'LAST-87736799M', 'TIM'),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -11,7 +11,7 @@ import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import java.time.LocalDate
 
@@ -155,18 +155,18 @@ class CreateContactIntegrationTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @EnumSource(IsOverEighteen::class)
-  fun `should record the estimated date of birth if supplied`(isOverEighteen: IsOverEighteen) {
+  @EnumSource(EstimatedIsOverEighteen::class)
+  fun `should record the estimated date of birth if supplied`(estimatedIsOverEighteen: EstimatedIsOverEighteen) {
     val request = CreateContactRequest(
       lastName = "last",
       firstName = "first",
       dateOfBirth = null,
-      isOverEighteen = isOverEighteen,
+      estimatedIsOverEighteen = estimatedIsOverEighteen,
       createdBy = "created",
     )
 
     val contactReturnedOnCreate = testAPIClient.createAContact(request)
-    assertThat(contactReturnedOnCreate.isOverEighteen).isEqualTo(isOverEighteen)
+    assertThat(contactReturnedOnCreate.estimatedIsOverEighteen).isEqualTo(estimatedIsOverEighteen)
     assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
   }
 
@@ -177,8 +177,8 @@ class CreateContactIntegrationTest : IntegrationTestBase() {
       assertThat(firstName).isEqualTo(request.firstName)
       assertThat(middleName).isEqualTo(request.middleName)
       assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-      if (request.isOverEighteen != null) {
-        assertThat(isOverEighteen).isEqualTo(request.isOverEighteen)
+      if (request.estimatedIsOverEighteen != null) {
+        assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
       }
       assertThat(createdBy).isEqualTo(request.createdBy)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import java.time.LocalDate
 
 class GetContactByIdIntegrationTest : IntegrationTestBase() {
@@ -65,7 +65,7 @@ class GetContactByIdIntegrationTest : IntegrationTestBase() {
       assertThat(firstName).isEqualTo("Jack")
       assertThat(middleName).isEqualTo("Middle")
       assertThat(dateOfBirth).isEqualTo(LocalDate.of(2000, 11, 21))
-      assertThat(isOverEighteen).isEqualTo(IsOverEighteen.YES)
+      assertThat(estimatedIsOverEighteen).isEqualTo(EstimatedIsOverEighteen.DO_NOT_KNOW)
       assertThat(createdBy).isEqualTo("TIM")
       assertThat(createdTime).isNotNull()
     }
@@ -76,16 +76,17 @@ class GetContactByIdIntegrationTest : IntegrationTestBase() {
     "2024-01-01,NO",
     "2004-01-01,YES",
   )
-  fun `should calculate is over eighteen if the dob is known`(dateOfBirth: LocalDate, isOverEighteen: IsOverEighteen) {
+  fun `should calculate is over eighteen if the dob is known`(dateOfBirth: LocalDate, estimatedIsOverEighteen: EstimatedIsOverEighteen) {
     val createdContactId = testAPIClient.createAContact(
       CreateContactRequest(
         firstName = "First",
         lastName = "Last",
         dateOfBirth = dateOfBirth,
+        estimatedIsOverEighteen = estimatedIsOverEighteen,
         createdBy = "USER1",
       ),
     ).id
     val contact = testAPIClient.getContact(createdContactId)
-    assertThat(contact.isOverEighteen).isEqualTo(isOverEighteen)
+    assertThat(contact.estimatedIsOverEighteen).isEqualTo(estimatedIsOverEighteen)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearch
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
@@ -43,7 +43,7 @@ class ContactControllerTest {
         id = 99,
         lastName = request.lastName,
         firstName = request.firstName,
-        isOverEighteen = IsOverEighteen.DO_NOT_KNOW,
+        estimatedIsOverEighteen = EstimatedIsOverEighteen.DO_NOT_KNOW,
         createdBy = request.createdBy,
         createdTime = LocalDateTime.now(),
       )
@@ -79,7 +79,7 @@ class ContactControllerTest {
       id = id,
       lastName = "last",
       firstName = "first",
-      isOverEighteen = IsOverEighteen.DO_NOT_KNOW,
+      estimatedIsOverEighteen = EstimatedIsOverEighteen.DO_NOT_KNOW,
       createdBy = "user",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -4,13 +4,12 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.reset
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -27,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.IsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearch
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactSearchRepository
@@ -87,49 +86,41 @@ class ContactServiceTest {
       }
     }
 
-    @TestFactory
-    fun `should create a contact without a date of birth successfully`() = listOf(
-      IsOverEighteen.YES to true,
-      IsOverEighteen.NO to false,
-      IsOverEighteen.DO_NOT_KNOW to null,
-    ).map { (requestIsOverEighteen, expectedIsOverEighteen) ->
-      DynamicTest.dynamicTest("when is over eighteen is $requestIsOverEighteen then expected is $expectedIsOverEighteen") {
-        reset(contactRepository)
-        val request = CreateContactRequest(
-          title = "mr",
-          lastName = "last",
-          firstName = "first",
-          middleName = "middle",
-          dateOfBirth = null,
-          requestIsOverEighteen,
-          createdBy = "created",
-        )
-        whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
+    @Test
+    fun `should create a contact without a date of birth successfully`() {
+      val request = CreateContactRequest(
+        title = "mr",
+        lastName = "last",
+        firstName = "first",
+        middleName = "middle",
+        dateOfBirth = null,
+        createdBy = "created",
+      )
+      whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
 
-        val createdContact = service.createContact(request)
+      val createdContact = service.createContact(request)
 
-        val contactCaptor = argumentCaptor<ContactEntity>()
-        verify(contactRepository).saveAndFlush(contactCaptor.capture())
-        with(contactCaptor.firstValue) {
-          assertThat(title).isEqualTo(request.title)
-          assertThat(lastName).isEqualTo(request.lastName)
-          assertThat(firstName).isEqualTo(request.firstName)
-          assertThat(middleName).isEqualTo(request.middleName)
-          assertNull(dateOfBirth)
-          assertThat(isOverEighteen).isEqualTo(expectedIsOverEighteen)
-          assertThat(createdBy).isEqualTo(request.createdBy)
-          assertThat(createdTime).isNotNull()
-        }
-        with(createdContact) {
-          assertThat(title).isEqualTo(request.title)
-          assertThat(lastName).isEqualTo(request.lastName)
-          assertThat(firstName).isEqualTo(request.firstName)
-          assertThat(middleName).isEqualTo(request.middleName)
-          assertNull(dateOfBirth)
-          assertThat(isOverEighteen).isEqualTo(requestIsOverEighteen)
-          assertThat(createdBy).isEqualTo(request.createdBy)
-          assertThat(createdTime).isNotNull()
-        }
+      val contactCaptor = argumentCaptor<ContactEntity>()
+      verify(contactRepository).saveAndFlush(contactCaptor.capture())
+      with(contactCaptor.firstValue) {
+        assertThat(title).isEqualTo(request.title)
+        assertThat(lastName).isEqualTo(request.lastName)
+        assertThat(firstName).isEqualTo(request.firstName)
+        assertThat(middleName).isEqualTo(request.middleName)
+        assertNull(dateOfBirth)
+        assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+        assertThat(createdTime).isNotNull()
+      }
+      with(createdContact) {
+        assertThat(title).isEqualTo(request.title)
+        assertThat(lastName).isEqualTo(request.lastName)
+        assertThat(firstName).isEqualTo(request.firstName)
+        assertThat(middleName).isEqualTo(request.middleName)
+        assertNull(dateOfBirth)
+        assertThat(estimatedIsOverEighteen).isEqualTo(estimatedIsOverEighteen)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+        assertThat(createdTime).isNotNull()
       }
     }
 
@@ -242,73 +233,33 @@ class ContactServiceTest {
   inner class GetContact {
     private val id = 123456L
 
-    @TestFactory
-    fun `should get a contact with a dob and is over 18 calculated`() = listOf(
-      LocalDate.now().minusYears(19) to IsOverEighteen.YES,
-      LocalDate.now().minusYears(18) to IsOverEighteen.YES,
-      LocalDate.now().minusYears(18).plusDays(1) to IsOverEighteen.NO,
-    ).map { (dob, expectedIsOverEighteen) ->
-      DynamicTest.dynamicTest("when dob is $dob then expected is $expectedIsOverEighteen") {
-        val entity = ContactEntity(
-          contactId = id,
-          title = "Mr",
-          lastName = "last",
-          middleName = "middle",
-          firstName = "first",
-          dateOfBirth = dob,
-          isOverEighteen = null,
-          createdBy = "user",
-          createdTime = LocalDateTime.now(),
-        )
-        whenever(contactRepository.findById(id)).thenReturn(Optional.of(entity))
-        val contact = service.getContact(id)
-        assertNotNull(contact)
-        with(contact!!) {
-          assertThat(id).isEqualTo(entity.contactId)
-          assertThat(title).isEqualTo(entity.title)
-          assertThat(lastName).isEqualTo(entity.lastName)
-          assertThat(firstName).isEqualTo(entity.firstName)
-          assertThat(middleName).isEqualTo(entity.middleName)
-          assertThat(dateOfBirth).isEqualTo(entity.dateOfBirth)
-          assertThat(isOverEighteen).isEqualTo(expectedIsOverEighteen)
-          assertThat(createdBy).isEqualTo(entity.createdBy)
-          assertThat(createdTime).isEqualTo(entity.createdTime)
-        }
-      }
-    }
-
-    @TestFactory
-    fun `should get a contact without dob successfully`() = listOf(
-      true to IsOverEighteen.YES,
-      false to IsOverEighteen.NO,
-      null to IsOverEighteen.DO_NOT_KNOW,
-    ).map { (storedIsOverEighteen, expectedIsOverEighteen) ->
-      DynamicTest.dynamicTest("when stored is $storedIsOverEighteen then expected is $expectedIsOverEighteen") {
-        val entity = ContactEntity(
-          contactId = id,
-          title = "Mr",
-          lastName = "last",
-          middleName = "middle",
-          firstName = "first",
-          dateOfBirth = null,
-          isOverEighteen = storedIsOverEighteen,
-          createdBy = "user",
-          createdTime = LocalDateTime.now(),
-        )
-        whenever(contactRepository.findById(id)).thenReturn(Optional.of(entity))
-        val contact = service.getContact(id)
-        assertNotNull(contact)
-        with(contact!!) {
-          assertThat(id).isEqualTo(entity.contactId)
-          assertThat(title).isEqualTo(entity.title)
-          assertThat(lastName).isEqualTo(entity.lastName)
-          assertThat(firstName).isEqualTo(entity.firstName)
-          assertThat(middleName).isEqualTo(entity.middleName)
-          assertThat(dateOfBirth).isNull()
-          assertThat(isOverEighteen).isEqualTo(expectedIsOverEighteen)
-          assertThat(createdBy).isEqualTo(entity.createdBy)
-          assertThat(createdTime).isEqualTo(entity.createdTime)
-        }
+    @ParameterizedTest
+    @EnumSource(EstimatedIsOverEighteen::class)
+    fun `should get a contact without dob successfully`(estimatedIsOverEighteen: EstimatedIsOverEighteen) {
+      val entity = ContactEntity(
+        contactId = id,
+        title = "Mr",
+        lastName = "last",
+        middleName = "middle",
+        firstName = "first",
+        dateOfBirth = null,
+        estimatedIsOverEighteen = estimatedIsOverEighteen,
+        createdBy = "user",
+        createdTime = LocalDateTime.now(),
+      )
+      whenever(contactRepository.findById(id)).thenReturn(Optional.of(entity))
+      val contact = service.getContact(id)
+      assertNotNull(contact)
+      with(contact!!) {
+        assertThat(id).isEqualTo(entity.contactId)
+        assertThat(title).isEqualTo(entity.title)
+        assertThat(lastName).isEqualTo(entity.lastName)
+        assertThat(firstName).isEqualTo(entity.firstName)
+        assertThat(middleName).isEqualTo(entity.middleName)
+        assertThat(dateOfBirth).isNull()
+        assertThat(estimatedIsOverEighteen).isEqualTo(entity.estimatedIsOverEighteen)
+        assertThat(createdBy).isEqualTo(entity.createdBy)
+        assertThat(createdTime).isEqualTo(entity.createdTime)
       }
     }
 
@@ -444,7 +395,7 @@ class ContactServiceTest {
       middleName = "middle",
       firstName = "first",
       dateOfBirth = LocalDate.of(1980, 2, 1),
-      isOverEighteen = null,
+      estimatedIsOverEighteen = EstimatedIsOverEighteen.DO_NOT_KNOW,
       createdBy = "user",
       createdTime = LocalDateTime.now(),
     )


### PR DESCRIPTION
# Remove isOverEighteen calculation from the get contact endpoint,  
# Rename isOverEighteen to estimatedIsOverEighteen for more clarity
# Save estimatedIsOverEighteen value to database and return it back - no calculations in the service 
