### PR TITLE
Create contact email sync endpoints, service and repository methods #34

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEmailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEmailEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+import java.time.LocalDateTime.now
+
+@Entity
+@Table(name = "contact_email")
+data class ContactEmailEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val contactEmailId: Long,
+
+  val contactId: Long? = null,
+
+  val emailType: String,
+
+  val emailAddress: String? = null,
+
+  val primaryEmail: Boolean = false,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime = now(),
+) {
+  var amendedBy: String? = null
+  var amendedTime: LocalDateTime? = null
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactEmailEntityMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactEmailEntityMappers.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping
+
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmail
+
+fun ContactEmailEntity.toModel(): ContactEmail {
+  return ContactEmail(
+    contactEmailId = this.contactEmailId,
+    contactId = this.contactId!!,
+    emailType = this.emailType,
+    emailAddress = this.emailAddress!!,
+    primaryEmail = this.primaryEmail,
+    createdBy = this.createdBy,
+    createdTime = this.createdTime,
+    amendedBy = this.amendedBy,
+    amendedTime = this.amendedTime,
+  )
+}
+
+fun List<ContactEmailEntity>.toModel() = map { it.toModel() }
+
+fun CreateContactEmailRequest.toEntity() = ContactEmailEntity(
+  contactEmailId = 0L,
+  contactId = contactId,
+  emailType = emailType,
+  emailAddress = emailAddress,
+  primaryEmail = primaryEmail,
+  createdBy = createdBy,
+  createdTime = createdTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactEmailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/CreateContactEmailRequest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Request to create a new contact email address")
+data class CreateContactEmailRequest(
+  @Schema(description = "Unique identifier for the contact", example = "123")
+  val contactId: Long,
+
+  @Schema(description = "Type of email", example = "MOBILE")
+  val emailType: String,
+
+  @Schema(description = "Email address", example = "+1234567890")
+  val emailAddress: String,
+
+  @Schema(description = "Indicates if this is the primary email address", example = "true")
+  val primaryEmail: Boolean,
+
+  @Schema(description = "User who created the entry", example = "admin")
+  val createdBy: String,
+
+  @Schema(description = "The timestamp of when the email was created", example = "2024-01-01T00:00:00Z")
+  val createdTime: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateContactEmailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/UpdateContactEmailRequest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Request to update a new contact email address")
+data class UpdateContactEmailRequest(
+  @Schema(description = "Unique identifier for the contact", example = "123")
+  val contactId: Long,
+
+  @Schema(description = "Type of email", example = "MOBILE")
+  val emailType: String,
+
+  @Schema(description = "Email address", example = "+1234567890")
+  val emailAddress: String,
+
+  @Schema(description = "Indicates if this is the primary email address", example = "true")
+  val primaryEmail: Boolean,
+
+  @Schema(description = "The id of the user who updated the contact email", example = "JD000001")
+  val updatedBy: String,
+
+  @Schema(description = "The timestamp of when the contact email was changed", example = "2024-01-01T00:00:00Z")
+  val updatedTime: LocalDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactEmail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactEmail.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Email related to a contact")
+data class ContactEmail(
+  @Schema(description = "Unique identifier for the contact email", example = "1")
+  val contactEmailId: Long,
+
+  @Schema(description = "Unique identifier for the contact", example = "123")
+  val contactId: Long,
+
+  @Schema(description = "Type of email", example = "MOBILE")
+  val emailType: String,
+
+  @Schema(description = "Email address", example = "+1234567890")
+  val emailAddress: String,
+
+  @Schema(description = "Indicates if this is the primary Email address", example = "true")
+  val primaryEmail: Boolean,
+
+  @Schema(description = "User who created the entry", example = "admin")
+  val createdBy: String,
+
+  @Schema(description = "Timestamp when the entry was created", example = "2023-09-23T10:15:30")
+  val createdTime: LocalDateTime,
+
+  @Schema(description = "User who amended the entry", example = "admin2")
+  val amendedBy: String?,
+
+  @Schema(description = "Timestamp when the entry was amended", example = "2023-09-24T12:00:00")
+  val amendedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactEmailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactEmailRepository.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
+
+interface ContactEmailRepository : JpaRepository<ContactEmailEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailSyncController.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.SyncContactEmailService
+
+@Tag(name = "Sync endpoints")
+@RestController
+@RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class ContactEmailSyncController(
+  val syncService: SyncContactEmailService,
+) {
+  @GetMapping(path = ["/contact-email/{contactEmailId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Returns the data for a contact email by contactEmailId",
+    description = """
+      Requires role: ROLE_CONTACTS_MIGRATION.
+      Used to get the details for one contact email.
+      """,
+  )
+  @PreAuthorize("hasAnyRole('CONTACTS_MIGRATION')")
+  fun getContactEmailById(
+    @Parameter(description = "The internal ID for a contact email.", required = true)
+    @PathVariable contactEmailId: Long,
+  ) = syncService.getContactEmailById(contactEmailId)
+
+  @DeleteMapping(path = ["/contact-email/{contactEmailId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Deletes one contact email by internal ID",
+    description = """
+      Requires role: ROLE_CONTACTS_MIGRATION.
+      Used to delete a contact email.
+      """,
+  )
+  @PreAuthorize("hasAnyRole('CONTACTS_MIGRATION')")
+  fun deleteContactEmailById(
+    @Parameter(description = "The internal ID for the contact email.", required = true)
+    @PathVariable contactEmailId: Long,
+  ) = syncService.deleteContactEmail(contactEmailId)
+
+  @PutMapping(path = ["/contact-email"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  @Operation(
+    summary = "Creates a new contact email",
+    description = """
+      Requires role: ROLE_CONTACTS_MIGRATION.
+      Used to create a contact email and associate it with a contact.
+      """,
+  )
+  @PreAuthorize("hasAnyRole('CONTACTS_MIGRATION')")
+  fun createContactEmail(
+    @Valid @RequestBody createContactEmailRequest: CreateContactEmailRequest,
+  ) = syncService.createContactEmail(createContactEmailRequest)
+
+  @PostMapping(path = ["/contact-email/{contactEmailId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  @Operation(
+    summary = "Updates a contact email with new or extra detail",
+    description = """
+      Requires role: ROLE_CONTACTS_MIGRATION.
+      Used to update a contact email.
+      """,
+  )
+  @PreAuthorize("hasAnyRole('CONTACTS_MIGRATION')")
+  fun updateContactEmail(
+    @Parameter(description = "The internal ID for the contact email.", required = true)
+    @PathVariable contactEmailId: Long,
+    @Valid @RequestBody updateContactEmailRequest: UpdateContactEmailRequest,
+  ) = syncService.updateContactEmail(contactEmailId, updateContactEmailRequest)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactEmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactEmailService.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import jakarta.validation.ValidationException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toModel
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmail
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactEmailRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+
+@Service
+@Transactional
+class SyncContactEmailService(
+  val contactRepository: ContactRepository,
+  val contactEmailRepository: ContactEmailRepository,
+) {
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional(readOnly = true)
+  fun getContactEmailById(contactEmailId: Long): ContactEmail {
+    val contactEmailEntity = contactEmailRepository.findById(contactEmailId)
+      .orElseThrow { EntityNotFoundException("Contact email with ID $contactEmailId not found") }
+    return contactEmailEntity.toModel()
+  }
+
+  fun deleteContactEmail(contactEmailId: Long) {
+    contactEmailRepository.findById(contactEmailId)
+      .orElseThrow { EntityNotFoundException("Contact email with ID $contactEmailId not found") }
+    contactEmailRepository.deleteById(contactEmailId)
+  }
+
+  fun createContactEmail(request: CreateContactEmailRequest): ContactEmail {
+    contactRepository.findById(request.contactId)
+      .orElseThrow { EntityNotFoundException("Contact with ID ${request.contactId} not found") }
+    return contactEmailRepository.saveAndFlush(request.toEntity()).toModel()
+  }
+
+  fun updateContactEmail(contactEmailId: Long, request: UpdateContactEmailRequest): ContactEmail {
+    val contact = contactRepository.findById(request.contactId)
+      .orElseThrow { EntityNotFoundException("Contact with ID ${request.contactId} not found") }
+
+    val emailEntity = contactEmailRepository.findById(contactEmailId)
+      .orElseThrow { EntityNotFoundException("Contact email with ID $contactEmailId not found") }
+
+    if (contact.contactId != emailEntity.contactId) {
+      logger.error("Contact email update specified for a contact not linked to this email")
+      throw ValidationException("Contact ID ${contact.contactId} is not linked to the email ${emailEntity.contactEmailId}")
+    }
+
+    val changedContactEmail = emailEntity.copy(
+      contactId = request.contactId,
+      emailType = request.emailType,
+      emailAddress = request.emailAddress,
+      primaryEmail = request.primaryEmail,
+    ).also {
+      it.amendedBy = request.updatedBy
+      it.amendedTime = request.updatedTime
+    }
+
+    return contactEmailRepository.saveAndFlush(changedContactEmail).toModel()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactEmailIntegrationTest.kt
@@ -1,0 +1,263 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmail
+import java.time.LocalDateTime
+
+class SyncContactEmailIntegrationTest : IntegrationTestBase() {
+
+  @Nested
+  inner class ContactEmailSyncTests {
+    private var savedContactId = 0L
+
+    @BeforeEach
+    fun initialiseData() {
+      val request = aMinimalCreateContactRequest()
+      val contactReturnedOnCreate = testAPIClient.createAContact(request)
+      assertContactsAreEqualExcludingTimestamps(contactReturnedOnCreate, request)
+      assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
+      savedContactId = contactReturnedOnCreate.id
+    }
+
+    @Test
+    fun `Sync endpoints should return unauthorized if no token provided`() {
+      webTestClient.get()
+        .uri("/sync/contact-email/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+
+      webTestClient.put()
+        .uri("/sync/contact-email")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(createContactEmailRequest(savedContactId))
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+
+      webTestClient.post()
+        .uri("/sync/contact-email/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(updateContactEmailRequest(savedContactId))
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+
+      webTestClient.delete()
+        .uri("/sync/contact-email/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `Sync endpoints should return forbidden without an authorised role on the token`() {
+      webTestClient.get()
+        .uri("/sync/contact-email/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+
+      webTestClient.put()
+        .uri("/sync/contact-email")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(createContactEmailRequest(savedContactId))
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+
+      webTestClient.post()
+        .uri("/sync/contact-email/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(updateContactEmailRequest(savedContactId))
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+
+      webTestClient.delete()
+        .uri("/sync/contact-email/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should get an existing contact email`() {
+      // From base data
+      val contactEmailId = 2L
+      val contactEmail = webTestClient.get()
+        .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_MIGRATION")))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(ContactEmail::class.java)
+        .returnResult().responseBody!!
+
+      with(contactEmail) {
+        assertThat(emailType).isEqualTo("PERSONAL")
+        assertThat(emailAddress).isEqualTo("miss.last@hotmail.com")
+        assertThat(primaryEmail).isTrue()
+      }
+    }
+
+    @Test
+    fun `should create a new contact email`() {
+      val contactEmail = webTestClient.put()
+        .uri("/sync/contact-email")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_MIGRATION")))
+        .bodyValue(createContactEmailRequest(savedContactId))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(ContactEmail::class.java)
+        .returnResult().responseBody!!
+
+      // The created email is returned
+      with(contactEmail) {
+        assertThat(contactEmailId).isGreaterThan(3)
+        assertThat(contactId).isEqualTo(savedContactId)
+        assertThat(emailType).isEqualTo("Personal")
+        assertThat(emailAddress).isEqualTo("test@test.co.uk")
+        assertThat(primaryEmail).isTrue()
+        assertThat(createdBy).isEqualTo("CREATE")
+        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      }
+    }
+
+    @Test
+    fun `should create and then update a contact email`() {
+      val contactEmail = webTestClient.put()
+        .uri("/sync/contact-email")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_MIGRATION")))
+        .bodyValue(createContactEmailRequest(savedContactId))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(ContactEmail::class.java)
+        .returnResult().responseBody!!
+
+      with(contactEmail) {
+        assertThat(emailType).isEqualTo("Personal")
+        assertThat(emailAddress).isEqualTo("test@test.co.uk")
+        assertThat(primaryEmail).isTrue()
+        assertThat(createdBy).isEqualTo("CREATE")
+        assertThat(createdTime).isAfter(LocalDateTime.now().minusMinutes(5))
+      }
+
+      val updatedEmail = webTestClient.post()
+        .uri("/sync/contact-email/{contactEmailId}", contactEmail.contactEmailId)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_MIGRATION")))
+        .bodyValue(updateContactEmailRequest(savedContactId))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(ContactEmail::class.java)
+        .returnResult().responseBody!!
+
+      // Check the updated copy
+      with(updatedEmail) {
+        assertThat(contactEmailId).isGreaterThan(4)
+        assertThat(contactId).isEqualTo(savedContactId)
+        assertThat(emailType).isEqualTo("Personal")
+        assertThat(emailAddress).isEqualTo("test@test.co.uk")
+        assertThat(amendedBy).isEqualTo("UPDATE")
+        assertThat(amendedTime).isAfter(LocalDateTime.now().minusMinutes(5))
+        assertThat(createdBy).isEqualTo("CREATE")
+        assertThat(createdTime).isNotNull()
+      }
+    }
+
+    @Test
+    fun `should delete an existing contact email`() {
+      val contactEmailId = 3L
+
+      webTestClient.delete()
+        .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_MIGRATION")))
+        .exchange()
+        .expectStatus()
+        .isOk
+
+      webTestClient.get()
+        .uri("/sync/contact-email/{contactEmailId}", contactEmailId)
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_MIGRATION")))
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
+      with(contact) {
+        assertThat(title).isEqualTo(request.title)
+        assertThat(lastName).isEqualTo(request.lastName)
+        assertThat(firstName).isEqualTo(request.firstName)
+        assertThat(middleName).isEqualTo(request.middleName)
+        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
+        if (request.estimatedIsOverEighteen != null) {
+          assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
+        }
+        assertThat(createdBy).isEqualTo(request.createdBy)
+      }
+    }
+
+    private fun updateContactEmailRequest(contactId: Long) =
+      UpdateContactEmailRequest(
+        contactId = contactId,
+        emailType = "Personal",
+        emailAddress = "test@test.co.uk",
+        primaryEmail = true,
+        updatedBy = "UPDATE",
+        updatedTime = LocalDateTime.now(),
+      )
+
+    private fun createContactEmailRequest(contactId: Long) =
+      CreateContactEmailRequest(
+        contactId = contactId,
+        emailType = "Personal",
+        emailAddress = "test@test.co.uk",
+        primaryEmail = true,
+        createdBy = "CREATE",
+      )
+  }
+
+  private fun aMinimalCreateContactRequest() = CreateContactRequest(
+    lastName = "last",
+    firstName = "first",
+    createdBy = "created",
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactEmailServiceTest.kt
@@ -1,0 +1,224 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.toEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactEmailRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactEmailRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+import java.time.LocalDateTime
+import java.util.*
+
+class SyncContactEmailServiceTest {
+  private val contactRepository: ContactRepository = mock()
+  private val contactEmailRepository: ContactEmailRepository = mock()
+  private val syncService = SyncContactEmailService(contactRepository, contactEmailRepository)
+
+  @Nested
+  inner class ContactEmailTests {
+    @Test
+    fun `should get a contact email by ID`() {
+      whenever(contactEmailRepository.findById(1L)).thenReturn(Optional.of(contactEmailEntity()))
+      val contactEmail = syncService.getContactEmailById(1L)
+      with(contactEmail) {
+        assertThat(emailType).isEqualTo("Personal")
+        assertThat(emailAddress).isEqualTo("test@test.com")
+        assertThat(emailAddress).isEqualTo("test@test.com")
+        assertThat(primaryEmail).isTrue()
+      }
+      verify(contactEmailRepository).findById(1L)
+    }
+
+    @Test
+    fun `should fail to get a contact email by ID when not found`() {
+      whenever(contactEmailRepository.findById(1L)).thenReturn(Optional.empty())
+      assertThrows<EntityNotFoundException> {
+        syncService.getContactEmailById(1L)
+      }
+      verify(contactEmailRepository).findById(1L)
+    }
+
+    @Test
+    fun `should create a contact email`() {
+      val request = createContactEmailRequest()
+      whenever(contactRepository.findById(1L)).thenReturn(Optional.of(contactEntity()))
+      whenever(contactEmailRepository.saveAndFlush(request.toEntity())).thenReturn(request.toEntity())
+
+      val contactEmail = syncService.createContactEmail(request)
+      val emailCaptor = argumentCaptor<ContactEmailEntity>()
+
+      verify(contactEmailRepository).saveAndFlush(emailCaptor.capture())
+
+      // Checks the entity saved
+      with(emailCaptor.firstValue) {
+        assertThat(emailType).isEqualTo(request.emailType)
+        assertThat(emailAddress).isEqualTo(request.emailAddress)
+        assertThat(primaryEmail).isEqualTo(request.primaryEmail)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+      }
+
+      // Checks the model response
+      with(contactEmail) {
+        assertThat(contactEmailId).isEqualTo(0L)
+        assertThat(emailType).isEqualTo(request.emailType)
+        assertThat(emailAddress).isEqualTo(request.emailAddress)
+        assertThat(primaryEmail).isEqualTo(request.primaryEmail)
+        assertThat(createdBy).isEqualTo(request.createdBy)
+      }
+
+      verify(contactRepository).findById(1L)
+    }
+
+    @Test
+    fun `should fail to create a contact email when the contact ID is not present`() {
+      val request = createContactEmailRequest()
+      whenever(contactRepository.findById(1L)).thenReturn(Optional.empty())
+      assertThrows<EntityNotFoundException> {
+        syncService.createContactEmail(request)
+      }
+      verifyNoInteractions(contactEmailRepository)
+    }
+
+    @Test
+    fun `should delete contact email by ID`() {
+      whenever(contactEmailRepository.findById(1L)).thenReturn(Optional.of(contactEmailEntity()))
+      syncService.deleteContactEmail(1L)
+      verify(contactEmailRepository).deleteById(1L)
+    }
+
+    @Test
+    fun `should fail to delete contact email by ID when not found`() {
+      whenever(contactEmailRepository.findById(1L)).thenReturn(Optional.empty())
+      assertThrows<EntityNotFoundException> {
+        syncService.deleteContactEmail(1L)
+      }
+      verify(contactEmailRepository).findById(1L)
+    }
+
+    @Test
+    fun `should update a contact email by ID`() {
+      val request = updateContactEmailRequest()
+      whenever(contactRepository.findById(1L)).thenReturn(Optional.of(contactEntity()))
+      whenever(contactEmailRepository.findById(1L)).thenReturn(Optional.of(request.toEntity()))
+      whenever(contactEmailRepository.saveAndFlush(any())).thenReturn(request.toEntity())
+
+      val updated = syncService.updateContactEmail(1L, request)
+
+      val emailCaptor = argumentCaptor<ContactEmailEntity>()
+
+      verify(contactEmailRepository).saveAndFlush(emailCaptor.capture())
+
+      // Checks the entity saved
+      with(emailCaptor.firstValue) {
+        assertThat(emailType).isEqualTo(request.emailType)
+        assertThat(emailAddress).isEqualTo(request.emailAddress)
+        assertThat(primaryEmail).isEqualTo(request.primaryEmail)
+        assertThat(amendedBy).isEqualTo(request.updatedBy)
+        assertThat(amendedTime).isEqualTo(request.updatedTime)
+      }
+
+      // Checks the model returned
+      with(updated) {
+        assertThat(emailType).isEqualTo(request.emailType)
+        assertThat(emailAddress).isEqualTo(request.emailAddress)
+        assertThat(primaryEmail).isEqualTo(request.primaryEmail)
+        assertThat(amendedBy).isEqualTo(request.updatedBy)
+        assertThat(amendedTime).isEqualTo(request.updatedTime)
+      }
+    }
+
+    @Test
+    fun `should fail to update a contact email by ID when contact is not found`() {
+      val updateRequest = updateContactEmailRequest()
+      whenever(contactRepository.findById(1L)).thenReturn(Optional.empty())
+      assertThrows<EntityNotFoundException> {
+        syncService.updateContactEmail(1L, updateRequest)
+      }
+      verifyNoInteractions(contactEmailRepository)
+    }
+
+    @Test
+    fun `should fail to update a contact email when contact email is not found`() {
+      val updateRequest = updateContactEmailRequest()
+      whenever(contactRepository.findById(1L)).thenReturn(Optional.of(contactEntity(1L)))
+      whenever(contactEmailRepository.findById(updateRequest.contactId)).thenReturn(Optional.empty())
+      assertThrows<EntityNotFoundException> {
+        syncService.updateContactEmail(1L, updateRequest)
+      }
+      verify(contactRepository).findById(updateRequest.contactId)
+      verify(contactEmailRepository).findById(1L)
+    }
+  }
+
+  private fun updateContactEmailRequest(contactId: Long = 1L) =
+    UpdateContactEmailRequest(
+      contactId = contactId,
+      emailType = "Personal",
+      emailAddress = "test@test.com",
+      primaryEmail = true,
+      updatedBy = "TEST",
+      updatedTime = LocalDateTime.now(),
+    )
+
+  private fun createContactEmailRequest() =
+    CreateContactEmailRequest(
+      contactId = 1L,
+      emailType = "Personal",
+      emailAddress = "test@test.com",
+      primaryEmail = true,
+      createdBy = "TEST",
+    )
+
+  private fun contactEntity(contactId: Long = 1L) =
+    ContactEntity(
+      contactId = contactId,
+      title = "Mr",
+      firstName = "John",
+      middleName = null,
+      lastName = "Smith",
+      dateOfBirth = null,
+      estimatedIsOverEighteen = EstimatedIsOverEighteen.NO,
+      createdBy = "TEST",
+      createdTime = LocalDateTime.now(),
+    )
+
+  private fun contactEmailEntity() =
+    ContactEmailEntity(
+      contactEmailId = 1L,
+      contactId = 1L,
+      emailType = "Personal",
+      emailAddress = "test@test.com",
+      primaryEmail = true,
+      createdBy = "TEST",
+    )
+
+  private fun UpdateContactEmailRequest.toEntity(contactEmailId: Long = 1L): ContactEmailEntity {
+    val updatedBy = this.updatedBy
+    val updatedTime = this.updatedTime
+
+    return ContactEmailEntity(
+      contactEmailId = contactEmailId,
+      contactId = this.contactId,
+      emailType = this.emailType,
+      emailAddress = this.emailAddress,
+      primaryEmail = this.primaryEmail,
+      createdBy = "TEST",
+    ).also {
+      it.amendedBy = updatedBy
+      it.amendedTime = updatedTime
+    }
+  }
+}


### PR DESCRIPTION
Changes :

Added following operations for data sync from NOMIS into DPS contact_email table

1) (Retrieve) GET /sync/contact-email{contactEmailId): ContactEmail  

2) (Create) PUT /sync/contact-email: ContactEmail { body: CreateContactEmailRequest }

3) (Update) POST /sync/contact-email/{contactEmailId}: ContactPhone { body: UpdateContactEmailRequest }

4) ames(Delete) DELETE /sync/contact-email/{contactEmailId)