### PR TITLE
PRC-150: Add is deceased flag and deceased date to get contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactEntity.kt
@@ -33,6 +33,11 @@ data class ContactEntity(
   @Enumerated(EnumType.STRING)
   val estimatedIsOverEighteen: EstimatedIsOverEighteen?,
 
+  @Column(name = "deceased_flag")
+  val isDeceased: Boolean,
+
+  val deceasedDate: LocalDate?,
+
   @Column(updatable = false)
   val createdBy: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/ContactsServiceMappers.kt
@@ -8,12 +8,12 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntit
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-fun ContactEntity.toModel() = Contact(
+fun ContactEntity.toModel() = GetContactResponse(
   id = this.contactId,
   title = this.title,
   lastName = this.lastName,
@@ -21,11 +21,11 @@ fun ContactEntity.toModel() = Contact(
   middleName = this.middleName,
   dateOfBirth = this.dateOfBirth,
   estimatedIsOverEighteen = this.estimatedIsOverEighteen,
+  isDeceased = this.isDeceased,
+  deceasedDate = this.deceasedDate,
   createdBy = this.createdBy,
   createdTime = this.createdTime,
 )
-
-fun Page<ContactEntity>.toModel(): Page<Contact> = map { it.toModel() }
 
 fun ContactWithAddressEntity.toModel() = ContactSearchResultItem(
   id = this.contactId,
@@ -98,6 +98,8 @@ private fun newContact(
     middleName,
     dateOfBirth,
     estimatedIsOverEighteen,
+    false,
+    null,
     createdBy,
     LocalDateTime.now(),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/GetContactResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/GetContactResponse.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "The details of a contact as an individual")
-data class Contact(
+data class GetContactResponse(
 
   @Schema(description = "The id of the contact", example = "123456")
   val id: Long,
@@ -28,6 +28,12 @@ data class Contact(
 
   @Schema(description = "Whether the contact is over 18, based on their date of birth if it is known", example = "YES")
   val estimatedIsOverEighteen: EstimatedIsOverEighteen?,
+
+  @Schema(description = "The date the contact deceased, if known", example = "1980-01-01")
+  val isDeceased: Boolean,
+
+  @Schema(description = "The date the contact deceased, if known", example = "1980-01-01", nullable = true)
+  val deceasedDate: LocalDate? = null,
 
   @Schema(description = "The id of the user who created the contact", example = "JD000001")
   val createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -28,8 +28,8 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -64,7 +64,7 @@ class ContactController(val contactService: ContactService) {
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = Contact::class),
+            schema = Schema(implementation = GetContactResponse::class),
           ),
         ],
       ),
@@ -101,7 +101,7 @@ class ContactController(val contactService: ContactService) {
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = Contact::class),
+            schema = Schema(implementation = GetContactResponse::class),
           ),
         ],
       ),
@@ -138,12 +138,6 @@ class ContactController(val contactService: ContactService) {
       ApiResponse(
         responseCode = "201",
         description = "Created the relationship successfully",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = Contact::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "400",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -12,8 +12,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRel
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactSearchRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
@@ -31,7 +31,7 @@ class ContactService(
   }
 
   @Transactional
-  fun createContact(request: CreateContactRequest): Contact {
+  fun createContact(request: CreateContactRequest): GetContactResponse {
     if (request.relationship != null) {
       validateRelationship(request.relationship)
     }
@@ -45,7 +45,7 @@ class ContactService(
     return createdContact
   }
 
-  fun getContact(id: Long): Contact? {
+  fun getContact(id: Long): GetContactResponse? {
     return contactRepository.findById(id).getOrNull()
       ?.toModel()
   }

--- a/src/main/resources/migrations/common/V2024.08.02.2__baseline_data.sql
+++ b/src/main/resources/migrations/common/V2024.08.02.2__baseline_data.sql
@@ -2,25 +2,26 @@
 -- Reference data
 -- =============================================
 
-insert into contact(contact_id, contact_type_code, title, last_name, first_name, middle_name, date_of_birth, estimated_is_over_eighteen, place_of_birth, gender, marital_status, language_code, comments, created_by, active)
-values (1, 'SOCIAL',   'MR',   'Last',   'Jack',       'Middle', '2000-11-21', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (2, 'SOCIAL',   'MISS', 'Last',   'Jacqueline', 'Middle', '2000-11-22', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (3, 'OFFICIAL', 'MRS', 'Last',    'Jane',       'Middle', '2000-11-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (4, 'SOCIAL',   'MR',   'Four',   'John',       'Middle', '2000-05-18', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (5, 'SOCIAL',   'MR',   'Five',   'Jon',        'Middle', '2000-09-21', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (6, 'SOCIAL',   'MR',   'Six',    'Johnny',     'Middle', '2000-10-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (7, 'SOCIAL',   'MR',   'Seven',  'Pete',       'Middle', '2015-08-29', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (8, 'SOCIAL',   'MR',   'Eight',  'Harry',      'Middle', '2015-12-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (9, 'SOCIAL',   'MR',   'Nine',   'Donald',     'Middle', '2000-11-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (10, 'SOCIAL',  'MS',   'Ten',    'Freya',      'Middle', '2000-11-24', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true),
-       (11, 'SOCIAL',  'MS',   'Eleven', 'Suki',       'Middle', '2000-11-25', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (12, 'SOCIAL',  'MRS',  'Twelve', 'Jane',       'Middle', '2000-11-26', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (13, 'SOCIAL',  'MRS',  'Thirteen', 'Mark',     'Middle', null, 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (14, 'SOCIAL',  'MRS',  'Fourteen', 'Phil',     'Middle', null, 'NO', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (15, 'SOCIAL',  'MRS',  'Fifteen', 'Carl',      'Middle', null, 'DO_NOT_KMOW', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (16, 'SOCIAL',  'MRS',  'NoAddress', 'Liam',      'Middle', null, 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (17, 'SOCIAL',  'MRS',  'NoAddress', 'Hannah',    'Middle', null, 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false),
-       (18, 'SOCIAL',  null,  'Minimal', 'Address',    null, null, null, null, null, null, null, null, 'TIM', true);
+insert into contact(contact_id, contact_type_code, title, last_name, first_name, middle_name, date_of_birth, estimated_is_over_eighteen, place_of_birth, gender, marital_status, language_code, comments, created_by, active, deceased_flag, deceased_date)
+values (1, 'SOCIAL',   'MR',   'Last',   'Jack',       'Middle', '2000-11-21', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (2, 'SOCIAL',   'MISS', 'Last',   'Jacqueline', 'Middle', '2000-11-22', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (3, 'OFFICIAL', 'MRS', 'Last',    'Jane',       'Middle', '2000-11-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (4, 'SOCIAL',   'MR',   'Four',   'John',       'Middle', '2000-05-18', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (5, 'SOCIAL',   'MR',   'Five',   'Jon',        'Middle', '2000-09-21', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (6, 'SOCIAL',   'MR',   'Six',    'Johnny',     'Middle', '2000-10-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (7, 'SOCIAL',   'MR',   'Seven',  'Pete',       'Middle', '2015-08-29', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (8, 'SOCIAL',   'MR',   'Eight',  'Harry',      'Middle', '2015-12-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (9, 'SOCIAL',   'MR',   'Nine',   'Donald',     'Middle', '2000-11-23', null, 'London', 'Male',   'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (10, 'SOCIAL',  'MS',   'Ten',    'Freya',      'Middle', '2000-11-24', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', true, false, null),
+       (11, 'SOCIAL',  'MS',   'Eleven', 'Suki',       'Middle', '2000-11-25', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (12, 'SOCIAL',  'MRS',  'Twelve', 'Jane',       'Middle', '2000-11-26', null, 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (13, 'SOCIAL',  'MRS',  'Thirteen', 'Mark',     'Middle', null, 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (14, 'SOCIAL',  'MRS',  'Fourteen', 'Phil',     'Middle', null, 'NO', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (15, 'SOCIAL',  'MRS',  'Fifteen', 'Carl',      'Middle', null, 'DO_NOT_KMOW', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (16, 'SOCIAL',  'MRS',  'NoAddress', 'Liam',    'Middle', null, 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (17, 'SOCIAL',  'MRS',  'NoAddress', 'Hannah',  'Middle', null, 'YES', 'London', 'Female', 'SINGLE', 'ENG', 'Comment', 'TIM', false, false, null),
+       (18, 'SOCIAL',  null,   'Minimal', 'Address',    null, null, null, null, null, null, null, null, 'TIM', true, false, null),
+       (19, 'SOCIAL',  null,   'Dead', 'Currently',     null, '1980-01-01', null, null, null, null, null, null, 'TIM', true, true, '2000-01-01');
 
 insert into contact_identity(contact_identity_id, contact_id, identity_type, identity_value, created_by)
 values (1, 1, 'DRIVING_LIC', 'LAST-87736799M', 'TIM'),

--- a/src/main/resources/migrations/common/V2024.08.19.1__reset_sequences.sql
+++ b/src/main/resources/migrations/common/V2024.08.19.1__reset_sequences.sql
@@ -2,7 +2,7 @@
 -- After loading reference data with specific sequence values, the sequences
 -- themselves need to be reset to the next number for generated ID values.
 --
-alter sequence if exists contact_contact_id_seq restart with 19;
+alter sequence if exists contact_contact_id_seq restart with 20;
 alter sequence if exists contact_address_contact_address_id_seq restart with 17;
 alter sequence if exists contact_email_contact_email_id_seq restart with 4;
 alter sequence if exists contact_identity_contact_identity_id_seq restart with 4;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -6,8 +6,8 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ReferenceCode
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
@@ -15,7 +15,7 @@ import java.net.URI
 
 class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAuthHelper: JwtAuthorisationHelper) {
 
-  fun createAContact(request: CreateContactRequest): Contact {
+  fun createAContact(request: CreateContactRequest): GetContactResponse {
     return webTestClient.post()
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
@@ -27,11 +27,11 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .isCreated
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectHeader().valuesMatch("Location", "/contact/(\\d)+")
-      .expectBody(Contact::class.java)
+      .expectBody(GetContactResponse::class.java)
       .returnResult().responseBody!!
   }
 
-  fun getContact(id: Long): Contact {
+  fun getContact(id: Long): GetContactResponse {
     return webTestClient.get()
       .uri("/contact/$id")
       .accept(MediaType.APPLICATION_JSON)
@@ -40,7 +40,7 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .expectStatus()
       .isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(Contact::class.java)
+      .expectBody(GetContactResponse::class.java)
       .returnResult().responseBody!!
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -12,11 +12,11 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 
 class AddContactRelationshipIntegrationTest : IntegrationTestBase() {
 
-  private lateinit var contact: Contact
+  private lateinit var contact: GetContactResponse
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.mo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import java.time.LocalDate
 
 class CreateContactIntegrationTest : IntegrationTestBase() {
@@ -170,7 +170,7 @@ class CreateContactIntegrationTest : IntegrationTestBase() {
     assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
   }
 
-  private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
+  private fun assertContactsAreEqualExcludingTimestamps(contact: GetContactResponse, request: CreateContactRequest) {
     with(contact) {
       assertThat(title).isEqualTo(request.title)
       assertThat(lastName).isEqualTo(request.lastName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -66,6 +66,27 @@ class GetContactByIdIntegrationTest : IntegrationTestBase() {
       assertThat(middleName).isEqualTo("Middle")
       assertThat(dateOfBirth).isEqualTo(LocalDate.of(2000, 11, 21))
       assertThat(estimatedIsOverEighteen).isNull()
+      assertThat(isDeceased).isFalse()
+      assertThat(deceasedDate).isNull()
+      assertThat(createdBy).isEqualTo("TIM")
+      assertThat(createdTime).isNotNull()
+    }
+  }
+
+  @Test
+  fun `should get deceased contacts`() {
+    val contact = testAPIClient.getContact(19)
+
+    with(contact) {
+      assertThat(id).isEqualTo(19)
+      assertThat(title).isNull()
+      assertThat(lastName).isEqualTo("Dead")
+      assertThat(firstName).isEqualTo("Currently")
+      assertThat(middleName).isNull()
+      assertThat(dateOfBirth).isEqualTo(LocalDate.of(1980, 1, 1))
+      assertThat(estimatedIsOverEighteen).isNull()
+      assertThat(isDeceased).isTrue()
+      assertThat(deceasedDate).isEqualTo(LocalDate.of(2000, 1, 1))
       assertThat(createdBy).isEqualTo("TIM")
       assertThat(createdTime).isNotNull()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactEmailIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactEmailIntegrationTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactEmailRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactEmailRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmail
 import java.time.LocalDateTime
 
@@ -21,11 +20,7 @@ class SyncContactEmailIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun initialiseData() {
-      val request = aMinimalCreateContactRequest()
-      val contactReturnedOnCreate = testAPIClient.createAContact(request)
-      assertContactsAreEqualExcludingTimestamps(contactReturnedOnCreate, request)
-      assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
-      savedContactId = contactReturnedOnCreate.id
+      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
     }
 
     @Test
@@ -219,20 +214,6 @@ class SyncContactEmailIntegrationTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isNotFound
-    }
-
-    private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
-      with(contact) {
-        assertThat(title).isEqualTo(request.title)
-        assertThat(lastName).isEqualTo(request.lastName)
-        assertThat(firstName).isEqualTo(request.firstName)
-        assertThat(middleName).isEqualTo(request.middleName)
-        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-        if (request.estimatedIsOverEighteen != null) {
-          assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
-        }
-        assertThat(createdBy).isEqualTo(request.createdBy)
-      }
     }
 
     private fun updateContactEmailRequest(contactId: Long) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactIdentityIntegrationTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactIdentityRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactIdentity
 import java.time.LocalDateTime
 
@@ -21,11 +20,7 @@ class SyncContactIdentityIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun initialiseData() {
-      val request = aMinimalCreateContactRequest()
-      val contactReturnedOnCreate = testAPIClient.createAContact(request)
-      assertContactsAreEqualExcludingTimestamps(contactReturnedOnCreate, request)
-      assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
-      savedContactId = contactReturnedOnCreate.id
+      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
     }
 
     @Test
@@ -212,20 +207,6 @@ class SyncContactIdentityIntegrationTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isNotFound
-    }
-
-    private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
-      with(contact) {
-        assertThat(title).isEqualTo(request.title)
-        assertThat(lastName).isEqualTo(request.lastName)
-        assertThat(firstName).isEqualTo(request.firstName)
-        assertThat(middleName).isEqualTo(request.middleName)
-        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-        if (request.estimatedIsOverEighteen != null) {
-          assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
-        }
-        assertThat(createdBy).isEqualTo(request.createdBy)
-      }
     }
 
     private fun updateContactIdentityRequest(contactId: Long) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactPhoneIntegrationTest.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactPhoneRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactPhoneRepository
 import java.time.LocalDateTime
@@ -25,11 +24,7 @@ class SyncContactPhoneIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun initialiseData() {
-      val request = aMinimalCreateContactRequest()
-      val contactReturnedOnCreate = testAPIClient.createAContact(request)
-      assertContactsAreEqualExcludingTimestamps(contactReturnedOnCreate, request)
-      assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
-      savedContactId = contactReturnedOnCreate.id
+      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
     }
 
     @Test
@@ -225,20 +220,6 @@ class SyncContactPhoneIntegrationTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isNotFound
-    }
-
-    private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
-      with(contact) {
-        assertThat(title).isEqualTo(request.title)
-        assertThat(lastName).isEqualTo(request.lastName)
-        assertThat(firstName).isEqualTo(request.firstName)
-        assertThat(middleName).isEqualTo(request.middleName)
-        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-        if (request.estimatedIsOverEighteen != null) {
-          assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
-        }
-        assertThat(createdBy).isEqualTo(request.createdBy)
-      }
     }
 
     private fun updateContactPhoneRequest(contactId: Long) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncContactRestrictionIntegrationTest.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactRestrictionRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactRestriction
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -22,11 +21,7 @@ class SyncContactRestrictionIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun initialiseData() {
-      val request = aMinimalCreateContactRequest()
-      val contactReturnedOnCreate = testAPIClient.createAContact(request)
-      assertContactsAreEqualExcludingTimestamps(contactReturnedOnCreate, request)
-      assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
-      savedContactId = contactReturnedOnCreate.id
+      savedContactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
     }
 
     @Test
@@ -223,20 +218,6 @@ class SyncContactRestrictionIntegrationTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isNotFound
-    }
-
-    private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
-      with(contact) {
-        assertThat(title).isEqualTo(request.title)
-        assertThat(lastName).isEqualTo(request.lastName)
-        assertThat(firstName).isEqualTo(request.firstName)
-        assertThat(middleName).isEqualTo(request.middleName)
-        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-        if (request.estimatedIsOverEighteen != null) {
-          assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
-        }
-        assertThat(createdBy).isEqualTo(request.createdBy)
-      }
     }
 
     private fun updateContactRestrictionRequest(contactId: Long) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncEndpointsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/SyncEndpointsIntegrationTest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.ContactAddress
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactAddressRepository
 import java.time.LocalDateTime
 
@@ -25,12 +24,7 @@ class SyncEndpointsIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun initialiseData() {
-      // Create a new contact for each test and expose its ID
-      val request = aMinimalCreateContactRequest()
-      val contactReturnedOnCreate = testAPIClient.createAContact(request)
-      assertContactsAreEqualExcludingTimestamps(contactReturnedOnCreate, request)
-      assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
-      contactId = contactReturnedOnCreate.id
+      contactId = testAPIClient.createAContact(aMinimalCreateContactRequest()).id
     }
 
     @Test
@@ -267,20 +261,6 @@ class SyncEndpointsIntegrationTest : IntegrationTestBase() {
 
       val afterCount = contactAddressRepository.count()
       assertThat(beforeCount).isEqualTo((afterCount + 1))
-    }
-
-    private fun assertContactsAreEqualExcludingTimestamps(contact: Contact, request: CreateContactRequest) {
-      with(contact) {
-        assertThat(title).isEqualTo(request.title)
-        assertThat(lastName).isEqualTo(request.lastName)
-        assertThat(firstName).isEqualTo(request.firstName)
-        assertThat(middleName).isEqualTo(request.middleName)
-        assertThat(dateOfBirth).isEqualTo(request.dateOfBirth)
-        if (request.estimatedIsOverEighteen != null) {
-          assertThat(estimatedIsOverEighteen).isEqualTo(request.estimatedIsOverEighteen)
-        }
-        assertThat(createdBy).isEqualTo(request.createdBy)
-      }
     }
 
     private fun updateContactAddressRequest(contactId: Long, verified: Boolean = false) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
@@ -18,8 +18,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelati
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Contact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
 import java.net.URI
 import java.time.LocalDate
@@ -39,11 +39,13 @@ class ContactControllerTest {
         firstName = "first",
         createdBy = "created",
       )
-      val expectedContact = Contact(
+      val expectedContact = GetContactResponse(
         id = 99,
         lastName = request.lastName,
         firstName = request.firstName,
         estimatedIsOverEighteen = EstimatedIsOverEighteen.DO_NOT_KNOW,
+        isDeceased = false,
+        deceasedDate = null,
         createdBy = request.createdBy,
         createdTime = LocalDateTime.now(),
       )
@@ -75,11 +77,13 @@ class ContactControllerTest {
   @Nested
   inner class GetContact {
     private val id = 123456L
-    private val contact = Contact(
+    private val contact = GetContactResponse(
       id = id,
       lastName = "last",
       firstName = "first",
       estimatedIsOverEighteen = EstimatedIsOverEighteen.DO_NOT_KNOW,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "user",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -244,6 +244,8 @@ class ContactServiceTest {
         firstName = "first",
         dateOfBirth = null,
         estimatedIsOverEighteen = estimatedIsOverEighteen,
+        isDeceased = false,
+        deceasedDate = null,
         createdBy = "user",
         createdTime = LocalDateTime.now(),
       )
@@ -299,6 +301,8 @@ class ContactServiceTest {
       firstName = "first",
       dateOfBirth = null,
       estimatedIsOverEighteen = EstimatedIsOverEighteen.DO_NOT_KNOW,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "user",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactEmailServiceTest.kt
@@ -191,6 +191,8 @@ class SyncContactEmailServiceTest {
       lastName = "Smith",
       dateOfBirth = null,
       estimatedIsOverEighteen = EstimatedIsOverEighteen.NO,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "TEST",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactIdentityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactIdentityServiceTest.kt
@@ -178,6 +178,8 @@ class SyncContactIdentityServiceTest {
       lastName = "Smith",
       dateOfBirth = null,
       estimatedIsOverEighteen = EstimatedIsOverEighteen.NO,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "TEST",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactPhoneServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactPhoneServiceTest.kt
@@ -198,6 +198,8 @@ class SyncContactPhoneServiceTest {
       lastName = "Smith",
       dateOfBirth = null,
       estimatedIsOverEighteen = EstimatedIsOverEighteen.NO,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "TEST",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactRestrictionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncContactRestrictionServiceTest.kt
@@ -196,6 +196,8 @@ class SyncContactRestrictionServiceTest {
       lastName = "Smith",
       dateOfBirth = null,
       estimatedIsOverEighteen = EstimatedIsOverEighteen.NO,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "TEST",
       createdTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/SyncServiceTest.kt
@@ -228,6 +228,8 @@ class SyncServiceTest {
       lastName = "Smith",
       dateOfBirth = null,
       estimatedIsOverEighteen = EstimatedIsOverEighteen.NO,
+      isDeceased = false,
+      deceasedDate = null,
       createdBy = "TEST",
       createdTime = LocalDateTime.now(),
     )


### PR DESCRIPTION
This is to support the contact confirmation page and anything else needing the full details of the contact.