### PR TITLE
PRC-173: Automatically clean and recreate the DB on changes applied

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     API_BASE_URL_PRISONER_SEARCH: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     FEATURE_EVENTS_SNS_ENABLED: true
+    SPRING_PROFILES_ACTIVE: auto-db-clean
 
   # This can be moved back into values.yml when all envs are configured with domain events secrets
   namespace_secrets:

--- a/src/main/resources/application-auto-db-clean.yaml
+++ b/src/main/resources/application-auto-db-clean.yaml
@@ -1,0 +1,6 @@
+spring:
+  flyway:
+    # This should be removed when we think the DB is stable, and we should be moving onto migrations for changes.
+    # The spring profile "dbclean" is set in the values-dev.yaml file, so it only applies to the DEV db.
+    clean-disabled: false
+    clean-on-validation-error: true


### PR DESCRIPTION
This should stop us having to manually clean the DB when the migrations change.
Only applied in DEV for now.