### PR TITLE
PRC-226: Events on contact phone create, update and delete

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,6 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for Spring Framework path directory traversal as it only affects
+#   applications that use WebMvc.fn or WebFlux.fn
+CVE-2024-38819

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/EventConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/EventConfiguration.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.HmppsQueueOutboundEventsPublisher
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsPublisher
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+
+@Configuration
+class EventConfiguration {
+
+  @Bean
+  fun outboundEventsPublisher(hmppsQueueService: HmppsQueueService, mapper: ObjectMapper, features: FeatureSwitches): OutboundEventsPublisher =
+    HmppsQueueOutboundEventsPublisher(hmppsQueueService, mapper, features)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacade.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
+
+@Service
+class ContactPhoneFacade(
+  private val contactPhoneService: ContactPhoneService,
+  private val outboundEventsService: OutboundEventsService,
+) {
+
+  fun create(contactId: Long, request: CreatePhoneRequest): ContactPhoneDetails {
+    return contactPhoneService.create(contactId, request).also {
+      outboundEventsService.send(OutboundEvent.CONTACT_PHONE_CREATED, it.contactPhoneId)
+    }
+  }
+
+  fun get(contactId: Long, contactPhoneId: Long): ContactPhoneDetails? {
+    return contactPhoneService.get(contactId, contactPhoneId)
+  }
+
+  fun update(contactId: Long, contactPhoneId: Long, request: UpdatePhoneRequest): ContactPhoneDetails {
+    return contactPhoneService.update(contactId, contactPhoneId, request).also {
+      outboundEventsService.send(OutboundEvent.CONTACT_PHONE_AMENDED, contactPhoneId)
+    }
+  }
+
+  fun delete(contactId: Long, contactPhoneId: Long) {
+    contactPhoneService.delete(contactId, contactPhoneId).also {
+      outboundEventsService.send(OutboundEvent.CONTACT_PHONE_DELETED, contactPhoneId)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
@@ -21,10 +21,10 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactPhoneFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -32,7 +32,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 @RestController
 @RequestMapping(value = ["contact/{contactId}/phone"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
-class ContactPhoneController(private val contactPhoneService: ContactPhoneService) {
+class ContactPhoneController(private val contactPhoneFacade: ContactPhoneFacade) {
 
   @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
@@ -72,7 +72,7 @@ class ContactPhoneController(private val contactPhoneService: ContactPhoneServic
     ) contactId: Long,
     @Valid @RequestBody request: CreatePhoneRequest,
   ): ResponseEntity<Any> {
-    val createdPhone = contactPhoneService.create(contactId, request)
+    val createdPhone = contactPhoneFacade.create(contactId, request)
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(createdPhone)
@@ -115,7 +115,7 @@ class ContactPhoneController(private val contactPhoneService: ContactPhoneServic
       example = "987654",
     ) contactPhoneId: Long,
   ): ResponseEntity<Any> {
-    return contactPhoneService.get(contactId, contactPhoneId)
+    return contactPhoneFacade.get(contactId, contactPhoneId)
       ?.let { ResponseEntity.ok(it) }
       ?: throw EntityNotFoundException("Contact phone with id ($contactPhoneId) not found for contact ($contactId)")
   }
@@ -163,7 +163,7 @@ class ContactPhoneController(private val contactPhoneService: ContactPhoneServic
     ) contactPhoneId: Long,
     @Valid @RequestBody request: UpdatePhoneRequest,
   ): ResponseEntity<Any> {
-    val updatedPhone = contactPhoneService.update(contactId, contactPhoneId, request)
+    val updatedPhone = contactPhoneFacade.update(contactId, contactPhoneId, request)
     return ResponseEntity.ok(updatedPhone)
   }
 
@@ -204,7 +204,7 @@ class ContactPhoneController(private val contactPhoneService: ContactPhoneServic
       example = "987654",
     ) contactPhoneId: Long,
   ): ResponseEntity<Any> {
-    contactPhoneService.delete(contactId, contactPhoneId)
+    contactPhoneFacade.delete(contactId, contactPhoneId)
     return ResponseEntity.noContent().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/HmppsQueueOutboundEventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/HmppsQueueOutboundEventsPublisher.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+
+class HmppsQueueOutboundEventsPublisher(
+  private val hmppsQueueService: HmppsQueueService,
+  private val mapper: ObjectMapper,
+  features: FeatureSwitches,
+) : OutboundEventsPublisher {
+  private val outboundEventsEnabled = features.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED)
+
+  companion object {
+    const val TOPIC_ID = "domainevents"
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  init {
+    log.info("Outbound SNS event publishing enabled = $outboundEventsEnabled")
+  }
+
+  private val domainEventsTopic by lazy {
+    hmppsQueueService.findByTopicId(TOPIC_ID) ?: throw RuntimeException("Topic with name $TOPIC_ID doesn't exist")
+  }
+
+  override fun send(event: OutboundHMPPSDomainEvent) {
+    if (outboundEventsEnabled) {
+      domainEventsTopic.snsClient.publish(
+        PublishRequest.builder()
+          .topicArn(domainEventsTopic.arn)
+          .message(mapper.writeValueAsString(event))
+          .messageAttributes(metaData(event))
+          .build(),
+      ).also { log.debug("Published {}", event) }
+
+      return
+    }
+
+    log.info("Ignoring publishing of event $event (feature switched off)")
+  }
+
+  private fun metaData(payload: OutboundHMPPSDomainEvent) =
+    mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build())
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsPublisher.kt
@@ -1,52 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Service
-import software.amazon.awssdk.services.sns.model.MessageAttributeValue
-import software.amazon.awssdk.services.sns.model.PublishRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.Feature
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.config.FeatureSwitches
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
-
-@Service
-class OutboundEventsPublisher(
-  private val hmppsQueueService: HmppsQueueService,
-  private val mapper: ObjectMapper,
-  private val features: FeatureSwitches,
-) {
-  private val outboundEventsEnabled = features.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED)
-
-  companion object {
-    const val TOPIC_ID = "domainevents"
-    private val log: Logger = LoggerFactory.getLogger(this::class.java)
-  }
-
-  init {
-    log.info("Outbound SNS event publishing enabled = $outboundEventsEnabled")
-  }
-
-  private val domainEventsTopic by lazy {
-    hmppsQueueService.findByTopicId(TOPIC_ID) ?: throw RuntimeException("Topic with name $TOPIC_ID doesn't exist")
-  }
-
-  fun send(event: OutboundHMPPSDomainEvent) {
-    if (outboundEventsEnabled) {
-      domainEventsTopic.snsClient.publish(
-        PublishRequest.builder()
-          .topicArn(domainEventsTopic.arn)
-          .message(mapper.writeValueAsString(event))
-          .messageAttributes(metaData(event))
-          .build(),
-      ).also { log.debug("Published {}", event) }
-
-      return
-    }
-
-    log.info("Ignoring publishing of event $event (feature switched off)")
-  }
-
-  private fun metaData(payload: OutboundHMPPSDomainEvent) =
-    mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build())
+interface OutboundEventsPublisher {
+  fun send(event: OutboundHMPPSDomainEvent)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -22,53 +22,71 @@ class OutboundEventsService(
         OutboundEvent.CONTACT_AMENDED,
         OutboundEvent.CONTACT_DELETED,
         -> {
-          publisher.send(outboundEvent.event(ContactInfo(identifier)))
+          sendSafely(outboundEvent, ContactInfo(identifier))
         }
+
         OutboundEvent.CONTACT_ADDRESS_CREATED,
         OutboundEvent.CONTACT_ADDRESS_AMENDED,
         OutboundEvent.CONTACT_ADDRESS_DELETED,
         -> {
-          publisher.send(outboundEvent.event(ContactAddressInfo(identifier)))
+          sendSafely(outboundEvent, ContactAddressInfo(identifier))
         }
+
         OutboundEvent.CONTACT_PHONE_CREATED,
         OutboundEvent.CONTACT_PHONE_AMENDED,
         OutboundEvent.CONTACT_PHONE_DELETED,
         -> {
-          publisher.send(outboundEvent.event(ContactPhoneInfo(identifier)))
+          sendSafely(outboundEvent, ContactPhoneInfo(identifier))
         }
+
         OutboundEvent.CONTACT_EMAIL_CREATED,
         OutboundEvent.CONTACT_EMAIL_AMENDED,
         OutboundEvent.CONTACT_EMAIL_DELETED,
         -> {
-          publisher.send(outboundEvent.event(ContactEmailInfo(identifier)))
+          sendSafely(outboundEvent, ContactEmailInfo(identifier))
         }
+
         OutboundEvent.CONTACT_IDENTITY_CREATED,
         OutboundEvent.CONTACT_IDENTITY_AMENDED,
         OutboundEvent.CONTACT_IDENTITY_DELETED,
         -> {
-          publisher.send(outboundEvent.event(ContactIdentityInfo(identifier)))
+          sendSafely(outboundEvent, ContactIdentityInfo(identifier))
         }
+
         OutboundEvent.CONTACT_RESTRICTION_CREATED,
         OutboundEvent.CONTACT_RESTRICTION_AMENDED,
         OutboundEvent.CONTACT_RESTRICTION_DELETED,
         -> {
-          publisher.send(outboundEvent.event(ContactRestrictionInfo(identifier)))
+          sendSafely(outboundEvent, ContactRestrictionInfo(identifier))
         }
+
         OutboundEvent.PRISONER_CONTACT_CREATED,
         OutboundEvent.PRISONER_CONTACT_AMENDED,
         OutboundEvent.PRISONER_CONTACT_DELETED,
         -> {
-          publisher.send(outboundEvent.event(PrisonerContactInfo(identifier)))
+          sendSafely(outboundEvent, PrisonerContactInfo(identifier))
         }
+
         OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
         OutboundEvent.PRISONER_CONTACT_RESTRICTION_AMENDED,
         OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED,
         -> {
-          publisher.send(outboundEvent.event(PrisonerContactRestrictionInfo(identifier)))
+          sendSafely(outboundEvent, PrisonerContactRestrictionInfo(identifier))
         }
       }
     } else {
       log.warn("Outbound event type $outboundEvent feature is configured off.")
+    }
+  }
+
+  private fun sendSafely(
+    outboundEvent: OutboundEvent,
+    info: AdditionalInformation,
+  ) {
+    try {
+      publisher.send(outboundEvent.event(info))
+    } catch (e: Exception) {
+      log.error("Unable to send event with type {} and info {}", outboundEvent, info, e)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
@@ -1,0 +1,138 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactPhoneNumberDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
+
+class ContactPhoneFacadeTest {
+
+  private val phoneService: ContactPhoneService = mock()
+  private val eventsService: OutboundEventsService = mock()
+  private val facade = ContactPhoneFacade(phoneService, eventsService)
+
+  private val contactId = 11L
+  private val contactPhoneId = 99L
+  private val contactPhoneDetails = createContactPhoneNumberDetails(id = contactPhoneId, contactId = contactId)
+
+  @Test
+  fun `should send event if create success`() {
+    whenever(phoneService.create(any(), any())).thenReturn(contactPhoneDetails)
+    whenever(eventsService.send(any(), any())).then {}
+    val request = CreatePhoneRequest(
+      phoneType = "MOB",
+      phoneNumber = "0777777777",
+      createdBy = "created",
+    )
+
+    val result = facade.create(contactId, request)
+
+    assertThat(result).isEqualTo(contactPhoneDetails)
+    verify(phoneService).create(contactId, request)
+    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_CREATED, contactPhoneId)
+  }
+
+  @Test
+  fun `should not send event if create throws exception and propagate the exception`() {
+    val expectedException = RuntimeException("Bang!")
+    whenever(phoneService.create(any(), any())).thenThrow(expectedException)
+    whenever(eventsService.send(any(), any())).then {}
+    val request = CreatePhoneRequest(
+      phoneType = "MOB",
+      phoneNumber = "0777777777",
+      createdBy = "created",
+    )
+
+    val exception = assertThrows<RuntimeException> {
+      facade.create(contactId, request)
+    }
+
+    assertThat(exception).isEqualTo(exception)
+    verify(phoneService).create(contactId, request)
+    verify(eventsService, never()).send(any(), any())
+  }
+
+  @Test
+  fun `should send event if update success`() {
+    whenever(phoneService.update(any(), any(), any())).thenReturn(contactPhoneDetails)
+    whenever(eventsService.send(any(), any())).then {}
+    val request = UpdatePhoneRequest(
+      phoneType = "MOB",
+      phoneNumber = "0777777777",
+      amendedBy = "amended",
+    )
+
+    val result = facade.update(contactId, contactPhoneId, request)
+
+    assertThat(result).isEqualTo(contactPhoneDetails)
+    verify(phoneService).update(contactId, contactPhoneId, request)
+    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_AMENDED, contactPhoneId)
+  }
+
+  @Test
+  fun `should not send event if update throws exception and propagate the exception`() {
+    val expectedException = RuntimeException("Bang!")
+    whenever(phoneService.update(any(), any(), any())).thenThrow(expectedException)
+    whenever(eventsService.send(any(), any())).then {}
+    val request = UpdatePhoneRequest(
+      phoneType = "MOB",
+      phoneNumber = "0777777777",
+      amendedBy = "amended",
+    )
+
+    val exception = assertThrows<RuntimeException> {
+      facade.update(contactId, contactPhoneId, request)
+    }
+
+    assertThat(exception).isEqualTo(exception)
+    verify(phoneService).update(contactId, contactPhoneId, request)
+    verify(eventsService, never()).send(any(), any())
+  }
+
+  @Test
+  fun `should send event if delete success`() {
+    whenever(phoneService.delete(any(), any())).then {}
+    whenever(eventsService.send(any(), any())).then {}
+
+    facade.delete(contactId, contactPhoneId)
+
+    verify(phoneService).delete(contactId, contactPhoneId)
+    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_DELETED, contactPhoneId)
+  }
+
+  @Test
+  fun `should not send event if delete throws exception and propagate the exception`() {
+    val expectedException = RuntimeException("Bang!")
+    whenever(phoneService.delete(any(), any())).thenThrow(expectedException)
+    whenever(eventsService.send(any(), any())).then {}
+
+    val exception = assertThrows<RuntimeException> {
+      facade.delete(contactId, contactPhoneId)
+    }
+
+    assertThat(exception).isEqualTo(exception)
+    verify(phoneService).delete(contactId, contactPhoneId)
+    verify(eventsService, never()).send(any(), any())
+  }
+
+  @Test
+  fun `should not send no event on get`() {
+    whenever(phoneService.get(any(), any())).thenReturn(contactPhoneDetails)
+
+    val result = facade.get(contactId, contactPhoneId)
+
+    assertThat(result).isEqualTo(contactPhoneDetails)
+    verify(phoneService).get(contactId, contactPhoneId)
+    verify(eventsService, never()).send(any(), any())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/IntegrationTestBase.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -17,6 +18,7 @@ import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
 @ExtendWith(HmppsAuthApiExtension::class, PrisonerSearchApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
+@Import(TestConfiguration::class)
 @ActiveProfiles("test")
 abstract class IntegrationTestBase {
 
@@ -26,11 +28,15 @@ abstract class IntegrationTestBase {
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
 
+  @Autowired
+  protected lateinit var stubEvents: StubOutboundEventsPublisher
+
   protected lateinit var testAPIClient: TestAPIClient
 
   @BeforeEach
   fun setupTestApiClient() {
     testAPIClient = TestAPIClient(webTestClient, jwtAuthHelper)
+    stubEvents.reset()
   }
 
   internal fun setAuthorisation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/StubOutboundEventsPublisher.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/StubOutboundEventsPublisher.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.AdditionalInformation
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsPublisher
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundHMPPSDomainEvent
+
+class StubOutboundEventsPublisher(private val receivedEvents: MutableList<OutboundHMPPSDomainEvent> = mutableListOf()) : OutboundEventsPublisher {
+  companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun send(event: OutboundHMPPSDomainEvent) {
+    receivedEvents.add(event)
+    logger.info("Stubbed sending event ($event)")
+  }
+
+  fun reset() {
+    receivedEvents.clear()
+  }
+
+  fun assertHasEvent(event: OutboundEvent, additionalInfo: AdditionalInformation) {
+    assertThat(receivedEvents)
+      .extracting(OutboundHMPPSDomainEvent::eventType, OutboundHMPPSDomainEvent::additionalInformation)
+      .contains(tuple(event.eventType, additionalInfo))
+  }
+
+  fun assertHasNoEvents(event: OutboundEvent, additionalInfo: AdditionalInformation) {
+    assertThat(receivedEvents)
+      .extracting(OutboundHMPPSDomainEvent::eventType, OutboundHMPPSDomainEvent::additionalInformation)
+      .doesNotContain(tuple(event.eventType, additionalInfo))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/TestConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/TestConfiguration.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+@TestConfiguration
+class TestConfiguration {
+
+  @Primary
+  @Bean
+  fun stubOutboundEventsPublisher(): StubOutboundEventsPublisher {
+    return StubOutboundEventsPublisher()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactPhoneIntegrationTest.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhoneInfo
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 
 class CreateContactPhoneIntegrationTest : H2IntegrationTestBase() {
   private var savedContactId = 0L
@@ -193,6 +195,7 @@ class CreateContactPhoneIntegrationTest : H2IntegrationTestBase() {
     val created = testAPIClient.createAContactPhone(savedContactId, request)
 
     assertEqualsExcludingTimestamps(created, request)
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_PHONE_CREATED, ContactPhoneInfo(created.contactPhoneId))
   }
 
   @Test
@@ -207,6 +210,7 @@ class CreateContactPhoneIntegrationTest : H2IntegrationTestBase() {
     val created = testAPIClient.createAContactPhone(savedContactId, request)
 
     assertEqualsExcludingTimestamps(created, request)
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_PHONE_CREATED, ContactPhoneInfo(created.contactPhoneId))
   }
 
   private fun assertEqualsExcludingTimestamps(phone: ContactPhoneDetails, request: CreatePhoneRequest) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactPhoneIntegrationTest.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.mo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhoneInfo
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 
 class DeleteContactPhoneIntegrationTest : H2IntegrationTestBase() {
   private var savedContactId = 0L
@@ -79,6 +81,7 @@ class DeleteContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact (-321) not found")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_DELETED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @Test
@@ -95,6 +98,7 @@ class DeleteContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact phone (-99) not found")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_DELETED, ContactPhoneInfo(-99))
   }
 
   @Test
@@ -114,5 +118,7 @@ class DeleteContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isNotFound
+
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_PHONE_DELETED, ContactPhoneInfo(savedContactPhoneId))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactPhoneIntegrationTest.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactPhoneInfo
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 
 class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
   private var savedContactId = 0L
@@ -103,6 +105,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: $expectedMessage")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @ParameterizedTest
@@ -122,6 +125,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure(s): $expectedMessage")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @ParameterizedTest
@@ -150,6 +154,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: Phone number invalid, it can only contain numbers, () and whitespace with an optional + at the start")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @Test
@@ -174,6 +179,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported phone type (SATELLITE)")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @Test
@@ -194,6 +200,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact (-321) not found")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @Test
@@ -214,6 +221,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Entity not found : Contact phone (-99) not found")
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(-99))
   }
 
   @Test
@@ -236,6 +244,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       assertThat(amendedBy).isEqualTo("amended")
       assertThat(amendedTime).isNotNull()
     }
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   @Test
@@ -258,6 +267,7 @@ class UpdateContactPhoneIntegrationTest : H2IntegrationTestBase() {
       assertThat(amendedBy).isEqualTo("amended")
       assertThat(amendedTime).isNotNull()
     }
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_PHONE_AMENDED, ContactPhoneInfo(savedContactPhoneId))
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneControllerTest.kt
@@ -9,17 +9,17 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactPhoneFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactPhoneNumberDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactPhoneService
 import java.time.LocalDateTime
 
 class ContactPhoneControllerTest {
 
-  private val service: ContactPhoneService = mock()
-  private val controller = ContactPhoneController(service)
+  private val facade: ContactPhoneFacade = mock()
+  private val controller = ContactPhoneController(facade)
 
   @Nested
   inner class CreateContactPhone {
@@ -32,13 +32,13 @@ class ContactPhoneControllerTest {
         null,
         "JAMES",
       )
-      whenever(service.create(1, request)).thenReturn(createdPhone)
+      whenever(facade.create(1, request)).thenReturn(createdPhone)
 
       val response = controller.create(1, request)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
       assertThat(response.body).isEqualTo(createdPhone)
-      verify(service).create(1, request)
+      verify(facade).create(1, request)
     }
 
     @Test
@@ -50,14 +50,14 @@ class ContactPhoneControllerTest {
         "JAMES",
       )
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(service.create(1, request)).thenThrow(expected)
+      whenever(facade.create(1, request)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
         controller.create(1, request)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(service).create(1, request)
+      verify(facade).create(1, request)
     }
   }
 
@@ -78,16 +78,16 @@ class ContactPhoneControllerTest {
 
     @Test
     fun `get phone if found by ids`() {
-      whenever(service.get(11, 99)).thenReturn(phone)
+      whenever(facade.get(11, 99)).thenReturn(phone)
 
-      val returnedPhone = service.get(11, 99)
+      val returnedPhone = facade.get(11, 99)
 
       assertThat(returnedPhone).isEqualTo(phone)
     }
 
     @Test
     fun `throw EntityNotFoundException when contact or phone cannot be found`() {
-      whenever(service.get(11, 99)).thenReturn(null)
+      whenever(facade.get(11, 99)).thenReturn(null)
       val exception = assertThrows<EntityNotFoundException> {
         controller.get(11, 99)
       }
@@ -106,13 +106,13 @@ class ContactPhoneControllerTest {
         null,
         "JAMES",
       )
-      whenever(service.update(1, 2, request)).thenReturn(updatedPhone)
+      whenever(facade.update(1, 2, request)).thenReturn(updatedPhone)
 
       val response = controller.update(1, 2, request)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
       assertThat(response.body).isEqualTo(updatedPhone)
-      verify(service).update(1, 2, request)
+      verify(facade).update(1, 2, request)
     }
 
     @Test
@@ -124,14 +124,14 @@ class ContactPhoneControllerTest {
         "JAMES",
       )
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(service.update(1, 2, request)).thenThrow(expected)
+      whenever(facade.update(1, 2, request)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
         controller.update(1, 2, request)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(service).update(1, 2, request)
+      verify(facade).update(1, 2, request)
     }
   }
 
@@ -139,25 +139,25 @@ class ContactPhoneControllerTest {
   inner class DeleteContactPhone {
     @Test
     fun `should return 204 if deleted successfully`() {
-      whenever(service.delete(1, 2)).then { }
+      whenever(facade.delete(1, 2)).then { }
 
       val response = controller.delete(1, 2)
 
       assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
-      verify(service).delete(1, 2)
+      verify(facade).delete(1, 2)
     }
 
     @Test
     fun `should propagate exceptions if delete fails`() {
       val expected = EntityNotFoundException("Couldn't find contact")
-      whenever(service.delete(1, 2)).thenThrow(expected)
+      whenever(facade.delete(1, 2)).thenThrow(expected)
 
       val exception = assertThrows<EntityNotFoundException> {
         controller.delete(1, 2)
       }
 
       assertThat(exception).isEqualTo(expected)
-      verify(service).delete(1, 2)
+      verify(facade).delete(1, 2)
     }
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,3 +15,12 @@ api:
     url:
       hmpps-auth: http://localhost:8090/auth
       prisoner-search: http://localhost:8092
+
+feature:
+  event:
+    contacts-api:
+      contact-phone:
+        created: true
+        amended: true
+        deleted: true
+


### PR DESCRIPTION
Added events on creating, updating or deleting a contact phone.

Added a stub events service so that we can test without needing to use localstack/SQS/SNS.