### PR TITLE
PRC-99: Add PATCH support for title and middleNames

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/patch/PatchContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/patch/PatchContactRequest.kt
@@ -2,11 +2,15 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import org.openapitools.jackson.nullable.JsonNullable
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import java.time.LocalDate
 
-@Schema(description = "Request to patch a new contact ")
+@Schema(
+  description = "Request to patch a new contact. " +
+    "firstName and lastName are not updatable so are intentionally missing from this request.",
+)
 data class PatchContactRequest(
 
   @Schema(description = "Whether the contact is a staff member", example = "false", nullable = false, type = "boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
@@ -28,6 +32,14 @@ data class PatchContactRequest(
 
   @Schema(description = "If the date of birth is not known, this indicates whether they are believed to be over 18 or not", type = "string", example = "YES", nullable = true, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   var estimatedIsOverEighteen: JsonNullable<EstimatedIsOverEighteen?> = JsonNullable.undefined(),
+
+  @Schema(description = "The title of the contact, if any", type = "string", example = "MR", nullable = true, maxLength = 12, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 12, message = "title must be <= 12 characters")
+  var title: JsonNullable<String> = JsonNullable.undefined(),
+
+  @Schema(description = "The middle names of the contact, if any", type = "string", example = "William", nullable = true, maxLength = 35, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 35, message = "middleNames must be <= 35 characters")
+  var middleNames: JsonNullable<String> = JsonNullable.undefined(),
 
   @Schema(description = "The id of the user who updated the contact", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
   val updatedBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPatchService.kt
@@ -27,6 +27,7 @@ class ContactPatchService(
     validateInterpreterRequiredType(request)
     validateDomesticStatusCode(request)
     validateStaffFlag(request)
+    validateTitle(request)
 
     val changedContact = contact.patchRequest(request)
 
@@ -44,6 +45,8 @@ class ContactPatchService(
       languageCode = request.languageCode.orElse(this.languageCode),
       dateOfBirth = request.dateOfBirth.orElse(this.dateOfBirth),
       estimatedIsOverEighteen = request.estimatedIsOverEighteen.orElse(this.estimatedIsOverEighteen),
+      title = request.title.orElse(this.title),
+      middleNames = request.middleNames.orElse(this.middleNames),
       amendedBy = request.updatedBy,
       amendedTime = LocalDateTime.now(),
     )
@@ -74,6 +77,14 @@ class ContactPatchService(
       val code = request.domesticStatus.get()!!
       referenceCodeService.getReferenceDataByGroupAndCode("DOMESTIC_STS", code)
         ?: throw ValidationException("Reference code with groupCode DOMESTIC_STS and code '$code' not found.")
+    }
+  }
+
+  private fun validateTitle(request: PatchContactRequest) {
+    if (request.title.isPresent && request.title.get() != null) {
+      val code = request.title.get()!!
+      referenceCodeService.getReferenceDataByGroupAndCode("TITLE", code)
+        ?: throw ValidationException("Reference code with groupCode TITLE and code '$code' not found.")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactPatchFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactPatchFacade.kt
@@ -20,8 +20,8 @@ class ContactPatchFacade(
   fun patch(id: Long, request: PatchContactRequest): PatchContactResponse {
     return contactService.patch(id, request)
       .also {
-        logger.info("Send patch domain event to {} {} ", OutboundEvent.PRISONER_CONTACT_AMENDED, id)
-        outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_AMENDED, id)
+        logger.info("Send patch domain event to {} {} ", OutboundEvent.CONTACT_AMENDED, id)
+        outboundEventsService.send(OutboundEvent.CONTACT_AMENDED, id)
       }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
@@ -7,22 +7,18 @@ import org.junit.jupiter.api.Test
 import org.openapitools.jackson.nullable.JsonNullable
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.context.TestPropertySource
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactInfo
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import java.time.LocalDate
 
-@TestPropertySource(
-  properties = [
-    "feature.event.contacts-api.prisoner-contact.amended=true",
-    "feature.events.sns.enabled=false",
-  ],
-)
 class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
   private val contactId = 21L
@@ -111,6 +107,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.languageCode).isEqualTo("ENG")
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -125,6 +122,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.languageCode).isEqualTo(null)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -139,6 +137,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.languageCode).isEqualTo("FRE-FRA")
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     private fun resetLanguageCode() {
@@ -151,6 +150,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.languageCode).isEqualTo("ENG")
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.reset()
     }
   }
 
@@ -170,6 +170,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.interpreterRequired).isEqualTo(true)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -183,6 +184,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.interpreterRequired).isEqualTo(true)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -200,6 +202,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
 
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported interpreter required type null.")
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     private fun resetInterpreterRequired(resetValue: Boolean) {
@@ -212,6 +215,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.interpreterRequired).isEqualTo(resetValue)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.reset()
     }
   }
 
@@ -229,6 +233,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.domesticStatus).isEqualTo("P")
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -243,6 +248,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.domesticStatus).isEqualTo(null)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -257,6 +263,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.domesticStatus).isEqualTo("M")
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     private fun resetDomesticStatus() {
@@ -269,6 +276,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.domesticStatus).isEqualTo("P")
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.reset()
     }
   }
 
@@ -287,6 +295,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.isStaff).isEqualTo(true)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -300,6 +309,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.isStaff).isEqualTo(true)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     @Test
@@ -317,6 +327,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
 
       assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported staff flag value null.")
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactId))
     }
 
     private fun resetStaffFlag(resetValue: Boolean) {
@@ -329,6 +340,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.isStaff).isEqualTo(resetValue)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.reset()
     }
   }
 
@@ -357,6 +369,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.dateOfBirth).isEqualTo(LocalDate.of(1982, 6, 15))
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactIdThatHasDOB))
     }
 
     @Test
@@ -369,6 +382,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.dateOfBirth).isNull()
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactIdThatHasDOB))
     }
 
     @Test
@@ -381,6 +395,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.dateOfBirth).isEqualTo(LocalDate.of(2000, 12, 25))
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactIdThatHasDOB))
     }
   }
 
@@ -410,6 +425,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.estimatedIsOverEighteen).isEqualTo(EstimatedIsOverEighteen.YES)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactIdThatHasEstimatedDOB))
     }
 
     @Test
@@ -422,6 +438,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.estimatedIsOverEighteen).isEqualTo(null)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactIdThatHasEstimatedDOB))
     }
 
     @Test
@@ -434,6 +451,131 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
 
       assertThat(res.estimatedIsOverEighteen).isEqualTo(EstimatedIsOverEighteen.DO_NOT_KNOW)
       assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactIdThatHasEstimatedDOB))
+    }
+  }
+
+  @Nested
+  inner class PatchNames {
+    private var contactThatHasAllNameFields = 0L
+
+    @BeforeEach
+    fun createContactWithDob() {
+      contactThatHasAllNameFields = testAPIClient.createAContact(
+        CreateContactRequest(
+          lastName = "Last",
+          firstName = "First",
+          middleNames = "Middle Names",
+          title = "MR",
+          createdBy = "created",
+        ),
+      ).id
+    }
+
+    @Test
+    fun `should not patch names when not provided`() {
+      val req = PatchContactRequest(
+        updatedBy = updatedByUser,
+      )
+      val res = testAPIClient.patchAContact(req, "/contact/$contactThatHasAllNameFields")
+
+      assertThat(res.firstName).isEqualTo("First")
+      assertThat(res.lastName).isEqualTo("Last")
+      assertThat(res.middleNames).isEqualTo("Middle Names")
+      assertThat(res.title).isEqualTo("MR")
+      assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactThatHasAllNameFields))
+    }
+
+    @Test
+    fun `should not patch first or last names`() {
+      val res = webTestClient.patch()
+        .uri("/contact/$contactThatHasAllNameFields")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+        .bodyValue(
+          """
+          { "firstName": "update first", "lastName": "update last", "middleNames": "update middle", "title": "MRS", "updatedBy": "$updatedByUser" }
+          """.trimIndent(),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(PatchContactResponse::class.java)
+        .returnResult().responseBody!!
+
+      assertThat(res.firstName).isEqualTo("First")
+      assertThat(res.lastName).isEqualTo("Last")
+      assertThat(res.middleNames).isEqualTo("update middle")
+      assertThat(res.title).isEqualTo("MRS")
+      assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactThatHasAllNameFields))
+    }
+
+    @Test
+    fun `should successfully patch middle name and title with null values`() {
+      val req = PatchContactRequest(
+        title = JsonNullable.of(null),
+        middleNames = JsonNullable.of(null),
+        updatedBy = updatedByUser,
+      )
+      val res = testAPIClient.patchAContact(req, "/contact/$contactThatHasAllNameFields")
+
+      assertThat(res.firstName).isEqualTo("First")
+      assertThat(res.lastName).isEqualTo("Last")
+      assertThat(res.middleNames).isNull()
+      assertThat(res.title).isNull()
+      assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactThatHasAllNameFields))
+    }
+
+    @Test
+    fun `should successfully patch middle name and title with a value`() {
+      val req = PatchContactRequest(
+        title = JsonNullable.of("MRS"),
+        middleNames = JsonNullable.of("Updated Middle"),
+        updatedBy = updatedByUser,
+      )
+      val res = testAPIClient.patchAContact(req, "/contact/$contactThatHasAllNameFields")
+
+      assertThat(res.firstName).isEqualTo("First")
+      assertThat(res.lastName).isEqualTo("Last")
+      assertThat(res.middleNames).isEqualTo("Updated Middle")
+      assertThat(res.title).isEqualTo("MRS")
+      assertThat(res.amendedBy).isEqualTo(updatedByUser)
+      stubEvents.assertHasEvent(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactThatHasAllNameFields))
+    }
+
+    @Test
+    fun `should not be able to patch to an invalid title value`() {
+      val req = PatchContactRequest(
+        title = JsonNullable.of("FOO"),
+        updatedBy = updatedByUser,
+      )
+
+      val uri = UriComponentsBuilder.fromPath("/contact/$contactThatHasAllNameFields")
+        .build()
+        .toUri()
+      val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
+      assertThat(errors.userMessage).isEqualTo("Validation failure: Reference code with groupCode TITLE and code 'FOO' not found.")
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactThatHasAllNameFields))
+    }
+
+    @Test
+    fun `should not be able to patch middle name when it's too long`() {
+      val req = PatchContactRequest(
+        middleNames = JsonNullable.of("".padEnd(36, 'X')),
+        updatedBy = updatedByUser,
+      )
+
+      val uri = UriComponentsBuilder.fromPath("/contact/$contactThatHasAllNameFields")
+        .build()
+        .toUri()
+      val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
+      assertThat(errors.userMessage).isEqualTo("Validation failure(s): middleNames must be <= 35 characters")
+      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_AMENDED, ContactInfo(contactThatHasAllNameFields))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactPatchFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactPatchFacadeTest.kt
@@ -31,6 +31,6 @@ class ContactPatchFacadeTest {
 
     assertThat(response).isEqualTo(result)
     verify(contactService).patch(contactId, request)
-    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_AMENDED, contactId)
+    verify(outboundEventsService).send(OutboundEvent.CONTACT_AMENDED, contactId)
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,3 +27,5 @@ feature:
         created: true
         amended: true
         deleted: true
+      contact:
+        amended: true


### PR DESCRIPTION
Also fixed the event being generated as it was prisoner contact (the relationship) instead of contact.