### PR TITLE
PRC-288: Add gender and description to get contact by id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactDetails.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "The details of a contact as an individual")
-data class GetContactResponse(
+data class ContactDetails(
 
   @Schema(description = "The id of the contact", example = "123456")
   val id: Long,
@@ -64,6 +64,12 @@ data class GetContactResponse(
 
   @Schema(description = "The description of the domestic status code", example = "Single", nullable = true)
   val domesticStatusDescription: String?,
+
+  @Schema(description = "The NOMIS code for the contacts gender. See reference data with group code 'GENDER'", examples = ["M", "F"], nullable = true)
+  val gender: String?,
+
+  @Schema(description = "The description of gender code. See reference data with group code 'GENDER'", examples = ["Male", "Female"], nullable = true)
+  val genderDescription: String?,
 
   @Schema(description = "The id of the user who created the contact", example = "JD000001")
   val createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -31,8 +31,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactSearch
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItemPage
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.patch.ContactPatchFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
@@ -71,7 +71,7 @@ class ContactController(
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = GetContactResponse::class),
+            schema = Schema(implementation = ContactDetails::class),
           ),
         ],
       ),
@@ -108,7 +108,7 @@ class ContactController(
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = GetContactResponse::class),
+            schema = Schema(implementation = ContactDetails::class),
           ),
         ],
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -14,11 +14,11 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateIdentit
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactIdentityDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateContactResponse
@@ -27,7 +27,7 @@ import java.net.URI
 
 class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAuthHelper: JwtAuthorisationHelper) {
 
-  fun createAContact(request: CreateContactRequest): GetContactResponse {
+  fun createAContact(request: CreateContactRequest): ContactDetails {
     return webTestClient.post()
       .uri("/contact")
       .accept(MediaType.APPLICATION_JSON)
@@ -39,7 +39,7 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .isCreated
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectHeader().valuesMatch("Location", "/contact/(\\d)+")
-      .expectBody(GetContactResponse::class.java)
+      .expectBody(ContactDetails::class.java)
       .returnResult().responseBody!!
   }
 
@@ -58,7 +58,7 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .returnResult().responseBody!!
   }
 
-  fun getContact(id: Long): GetContactResponse {
+  fun getContact(id: Long): ContactDetails {
     return webTestClient.get()
       .uri("/contact/$id")
       .accept(MediaType.APPLICATION_JSON)
@@ -67,7 +67,7 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .expectStatus()
       .isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(GetContactResponse::class.java)
+      .expectBody(ContactDetails::class.java)
       .returnResult().responseBody!!
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -12,11 +12,11 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.AddContactRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 
 class AddContactRelationshipIntegrationTest : H2IntegrationTestBase() {
 
-  private lateinit var contact: GetContactResponse
+  private lateinit var contact: ContactDetails
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIntegrationTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.mo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import java.time.LocalDate
 
 class CreateContactIntegrationTest : H2IntegrationTestBase() {
@@ -170,7 +170,7 @@ class CreateContactIntegrationTest : H2IntegrationTestBase() {
     assertThat(contactReturnedOnCreate).isEqualTo(testAPIClient.getContact(contactReturnedOnCreate.id))
   }
 
-  private fun assertContactsAreEqualExcludingTimestamps(contact: GetContactResponse, request: CreateContactRequest) {
+  private fun assertContactsAreEqualExcludingTimestamps(contact: ContactDetails, request: CreateContactRequest) {
     with(contact) {
       assertThat(title).isEqualTo(request.title)
       assertThat(lastName).isEqualTo(request.lastName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -231,6 +231,17 @@ class GetContactByIdIntegrationTest : H2IntegrationTestBase() {
   }
 
   @Test
+  fun `should get contacts with gender details`() {
+    val contact = testAPIClient.getContact(16)
+
+    with(contact) {
+      assertThat(id).isEqualTo(16)
+      assertThat(gender).isEqualTo("F")
+      assertThat(genderDescription).isEqualTo("Female")
+    }
+  }
+
+  @Test
   fun `should get contacts with domestic status`() {
     val contact = testAPIClient.getContact(1)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactControllerTest.kt
@@ -25,8 +25,8 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.GetContactResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.patch.ContactPatchFacade
 import java.net.URI
@@ -48,7 +48,7 @@ class ContactControllerTest {
         firstName = "first",
         createdBy = "created",
       )
-      val expectedContact = GetContactResponse(
+      val expectedContact = ContactDetails(
         id = 99,
         lastName = request.lastName,
         firstName = request.firstName,
@@ -64,6 +64,8 @@ class ContactControllerTest {
         identities = listOf(createContactIdentityDetails()),
         domesticStatusCode = "S",
         domesticStatusDescription = "Single",
+        gender = null,
+        genderDescription = null,
         createdBy = request.createdBy,
         createdTime = LocalDateTime.now(),
       )
@@ -95,7 +97,7 @@ class ContactControllerTest {
   @Nested
   inner class GetContact {
     private val id = 123456L
-    private val contact = GetContactResponse(
+    private val contact = ContactDetails(
       id = id,
       lastName = "last",
       firstName = "first",
@@ -111,6 +113,8 @@ class ContactControllerTest {
       identities = listOf(createContactIdentityDetails()),
       domesticStatusCode = null,
       domesticStatusDescription = null,
+      gender = null,
+      genderDescription = null,
       createdBy = "user",
       createdTime = LocalDateTime.now(),
     )


### PR DESCRIPTION
Also renamed GetContactResponse to ContactDetails to match other "get by id" domain objects