### PR TITLE
PRC-312: Accept duplicates in migration and add more detail to outbound events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacade.kt
@@ -17,23 +17,35 @@ class ContactEmailFacade(
 
   fun create(contactId: Long, request: CreateEmailRequest): ContactEmailDetails {
     return contactEmailService.create(contactId, request).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_CREATED, it.contactEmailId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_EMAIL_CREATED,
+        identifier = it.contactEmailId,
+        contactId = contactId,
+      )
     }
   }
 
   fun update(contactId: Long, contactEmailId: Long, request: UpdateEmailRequest): ContactEmailDetails {
     return contactEmailService.update(contactId, contactEmailId, request).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_AMENDED, contactEmailId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_EMAIL_AMENDED,
+        identifier = contactEmailId,
+        contactId = contactId,
+      )
+    }
+  }
+
+  fun delete(contactId: Long, contactEmailId: Long) {
+    contactEmailService.delete(contactId, contactEmailId).also {
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_EMAIL_DELETED,
+        identifier = contactEmailId,
+        contactId = contactId,
+      )
     }
   }
 
   fun get(contactId: Long, contactEmailId: Long): ContactEmailDetails {
     return contactEmailService.get(contactId, contactEmailId) ?: throw EntityNotFoundException("Contact email with id ($contactEmailId) not found for contact ($contactId)")
-  }
-
-  fun delete(contactId: Long, contactEmailId: Long) {
-    contactEmailService.delete(contactId, contactEmailId).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_DELETED, contactEmailId)
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacade.kt
@@ -17,13 +17,21 @@ class ContactIdentityFacade(
 
   fun create(contactId: Long, request: CreateIdentityRequest): ContactIdentityDetails {
     return contactIdentityService.create(contactId, request).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_CREATED, it.contactIdentityId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_IDENTITY_CREATED,
+        identifier = it.contactIdentityId,
+        contactId = contactId,
+      )
     }
   }
 
   fun update(contactId: Long, contactIdentityId: Long, request: UpdateIdentityRequest): ContactIdentityDetails {
     return contactIdentityService.update(contactId, contactIdentityId, request).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_AMENDED, contactIdentityId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_IDENTITY_AMENDED,
+        identifier = contactIdentityId,
+        contactId = contactId,
+      )
     }
   }
 
@@ -33,7 +41,11 @@ class ContactIdentityFacade(
 
   fun delete(contactId: Long, contactIdentityId: Long) {
     contactIdentityService.delete(contactId, contactIdentityId).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_DELETED, contactIdentityId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_IDENTITY_DELETED,
+        identifier = contactIdentityId,
+        contactId = contactId,
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacade.kt
@@ -16,7 +16,11 @@ class ContactPhoneFacade(
 
   fun create(contactId: Long, request: CreatePhoneRequest): ContactPhoneDetails {
     return contactPhoneService.create(contactId, request).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_PHONE_CREATED, it.contactPhoneId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_PHONE_CREATED,
+        identifier = it.contactPhoneId,
+        contactId = contactId,
+      )
     }
   }
 
@@ -26,13 +30,21 @@ class ContactPhoneFacade(
 
   fun update(contactId: Long, contactPhoneId: Long, request: UpdatePhoneRequest): ContactPhoneDetails {
     return contactPhoneService.update(contactId, contactPhoneId, request).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_PHONE_AMENDED, contactPhoneId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_PHONE_AMENDED,
+        identifier = contactPhoneId,
+        contactId = contactId,
+      )
     }
   }
 
   fun delete(contactId: Long, contactPhoneId: Long) {
     contactPhoneService.delete(contactId, contactPhoneId).also {
-      outboundEventsService.send(OutboundEvent.CONTACT_PHONE_DELETED, contactPhoneId)
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_PHONE_DELETED,
+        identifier = contactPhoneId,
+        contactId = contactId,
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressPhoneRepository.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressPhoneEntity
 
@@ -10,4 +12,8 @@ interface ContactAddressPhoneRepository : JpaRepository<ContactAddressPhoneEntit
   fun findByContactId(contactId: Long): List<ContactAddressPhoneEntity>
 
   fun deleteByContactPhoneId(contactPhoneId: Long)
+
+  @Modifying
+  @Query("delete from ContactAddressPhoneEntity cap where cap.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressRepository.kt
@@ -1,8 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressEntity
 
 @Repository
-interface ContactAddressRepository : JpaRepository<ContactAddressEntity, Long>
+interface ContactAddressRepository : JpaRepository<ContactAddressEntity, Long> {
+
+  @Modifying
+  @Query("delete from ContactAddressEntity ca where ca.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactEmailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactEmailRepository.kt
@@ -1,9 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
 
 interface ContactEmailRepository : JpaRepository<ContactEmailEntity, Long> {
   fun findByContactId(contactId: Long): List<ContactEmailEntity>
   fun findByContactIdAndContactEmailId(contactId: Long, contactIdentityId: Long): ContactEmailEntity?
+
+  @Modifying
+  @Query("delete from ContactEmailEntity ce where ce.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactEmploymentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactEmploymentRepository.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmploymentEntity
 
-interface ContactEmploymentRepository : JpaRepository<ContactEmploymentEntity, Long>
+interface ContactEmploymentRepository : JpaRepository<ContactEmploymentEntity, Long> {
+  @Modifying
+  @Query("delete from ContactEmploymentEntity ce where ce.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactIdentityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactIdentityRepository.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactIdentityEntity
 
-interface ContactIdentityRepository : JpaRepository<ContactIdentityEntity, Long>
+interface ContactIdentityRepository : JpaRepository<ContactIdentityEntity, Long> {
+  @Modifying
+  @Query("delete from ContactIdentityEntity ci where ci.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactPhoneRepository.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactPhoneEntity
 
-interface ContactPhoneRepository : JpaRepository<ContactPhoneEntity, Long>
+interface ContactPhoneRepository : JpaRepository<ContactPhoneEntity, Long> {
+  @Modifying
+  @Query("delete from ContactPhoneEntity cp where cp.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 
 @Repository
-interface ContactRepository : JpaRepository<ContactEntity, Long>
+interface ContactRepository : JpaRepository<ContactEntity, Long> {
+  @Modifying
+  @Query("delete from ContactEntity c where c.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRestrictionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactRestrictionRepository.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactRestrictionEntity
 
-interface ContactRestrictionRepository : JpaRepository<ContactRestrictionEntity, Long>
+interface ContactRestrictionRepository : JpaRepository<ContactRestrictionEntity, Long> {
+  @Modifying
+  @Query("delete from ContactRestrictionEntity cr where cr.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRepository.kt
@@ -1,8 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
 
 @Repository
-interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long>
+interface PrisonerContactRepository : JpaRepository<PrisonerContactEntity, Long> {
+  fun findAllByContactId(contactId: Long): List<PrisonerContactEntity>
+
+  @Modifying
+  @Query("delete from PrisonerContactEntity pc where pc.contactId = :contactId")
+  fun deleteAllByContactId(contactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRestrictionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/PrisonerContactRestrictionRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactRestrictionEntity
 
 @Repository
-interface PrisonerContactRestrictionRepository : JpaRepository<PrisonerContactRestrictionEntity, Long>
+interface PrisonerContactRestrictionRepository : JpaRepository<PrisonerContactRestrictionEntity, Long> {
+  @Modifying
+  @Query("delete from PrisonerContactRestrictionEntity pcr where pcr.prisonerContactId = :prisonerContactId")
+  fun deleteAllByPrisonerContactId(prisonerContactId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -4,218 +4,272 @@ import java.time.LocalDateTime
 
 enum class OutboundEvent(val eventType: String) {
   CONTACT_CREATED("contacts-api.contact.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact has been created",
       )
   },
   CONTACT_AMENDED("contacts-api.contact.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact has been amended",
       )
   },
   CONTACT_DELETED("contacts-api.contact.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact has been deleted",
       )
   },
   CONTACT_ADDRESS_CREATED("contacts-api.contact-address.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact address has been created",
       )
   },
   CONTACT_ADDRESS_AMENDED("contacts-api.contact-address.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact address has been amended",
       )
   },
   CONTACT_ADDRESS_DELETED("contacts-api.contact-address.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact address has been deleted",
       )
   },
   CONTACT_PHONE_CREATED("contacts-api.contact-phone.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact phone number has been created",
       )
   },
   CONTACT_PHONE_AMENDED("contacts-api.contact-phone.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact phone number has been amended",
       )
   },
   CONTACT_PHONE_DELETED("contacts-api.contact-phone.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact phone number has been deleted",
       )
   },
   CONTACT_EMAIL_CREATED("contacts-api.contact-email.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact email address has been created",
       )
   },
   CONTACT_EMAIL_AMENDED("contacts-api.contact-email.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact email address has been amended",
       )
   },
   CONTACT_EMAIL_DELETED("contacts-api.contact-email.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact email address has been deleted",
       )
   },
   CONTACT_IDENTITY_CREATED("contacts-api.contact-identity.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact proof of identity has been created",
       )
   },
   CONTACT_IDENTITY_AMENDED("contacts-api.contact-identity.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact proof of identity has been amended",
       )
   },
   CONTACT_IDENTITY_DELETED("contacts-api.contact-identity.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact proof of identity has been deleted",
       )
   },
   CONTACT_RESTRICTION_CREATED("contacts-api.contact-restriction.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact restriction has been created",
       )
   },
   CONTACT_RESTRICTION_AMENDED("contacts-api.contact-restriction.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact restriction has been amended",
       )
   },
   CONTACT_RESTRICTION_DELETED("contacts-api.contact-restriction.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A contact restriction has been deleted",
       )
   },
   PRISONER_CONTACT_CREATED("contacts-api.prisoner-contact.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A prisoner contact has been created",
       )
   },
   PRISONER_CONTACT_AMENDED("contacts-api.prisoner-contact.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A prisoner contact has been amended",
       )
   },
   PRISONER_CONTACT_DELETED("contacts-api.prisoner-contact.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A prisoner contact has been deleted",
       )
   },
   PRISONER_CONTACT_RESTRICTION_CREATED("contacts-api.prisoner-contact-restriction.created") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A prisoner contact restriction has been created",
       )
   },
   PRISONER_CONTACT_RESTRICTION_AMENDED("contacts-api.prisoner-contact-restriction.amended") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A prisoner contact restriction has been amended",
       )
   },
   PRISONER_CONTACT_RESTRICTION_DELETED("contacts-api.prisoner-contact-restriction.deleted") {
-    override fun event(additionalInformation: AdditionalInformation) =
+    override fun event(additionalInformation: AdditionalInformation, personReference: PersonReference?) =
       OutboundHMPPSDomainEvent(
         eventType = eventType,
         additionalInformation = additionalInformation,
+        personReference = personReference,
         description = "A prisoner contact restriction has been deleted",
       )
   },
   ;
 
-  abstract fun event(additionalInformation: AdditionalInformation): OutboundHMPPSDomainEvent
+  abstract fun event(
+    additionalInformation: AdditionalInformation,
+    personReference: PersonReference? = null,
+  ): OutboundHMPPSDomainEvent
 }
 
-interface AdditionalInformation
+abstract class AdditionalInformation {
+  val source: Source = Source.DPS
+}
 
 data class OutboundHMPPSDomainEvent(
   val eventType: String,
   val additionalInformation: AdditionalInformation,
+  val personReference: PersonReference? = null,
   val version: String = "1",
   val description: String,
   val occurredAt: LocalDateTime = LocalDateTime.now(),
 )
 
 // Event content - this is mapped into JSON by the ObjectMapper as the event body
-data class ContactInfo(val contactId: Long) : AdditionalInformation
-data class ContactAddressInfo(val contactAddressId: Long) : AdditionalInformation
-data class ContactPhoneInfo(val contactPhoneId: Long) : AdditionalInformation
-data class ContactEmailInfo(val contactEmailId: Long) : AdditionalInformation
-data class ContactIdentityInfo(val contactIdentityId: Long) : AdditionalInformation
-data class ContactRestrictionInfo(val contactRestrictionId: Long) : AdditionalInformation
-data class PrisonerContactInfo(val prisonerContactId: Long) : AdditionalInformation
-data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long) : AdditionalInformation
+data class ContactInfo(val contactId: Long) : AdditionalInformation()
+data class ContactAddressInfo(val contactAddressId: Long) : AdditionalInformation()
+data class ContactPhoneInfo(val contactPhoneId: Long) : AdditionalInformation()
+data class ContactEmailInfo(val contactEmailId: Long) : AdditionalInformation()
+data class ContactIdentityInfo(val contactIdentityId: Long) : AdditionalInformation()
+data class ContactRestrictionInfo(val contactRestrictionId: Long) : AdditionalInformation()
+data class PrisonerContactInfo(val prisonerContactId: Long) : AdditionalInformation()
+data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long) : AdditionalInformation()
+enum class Source { DPS }
+enum class Identifier { NOMS, DPS_CONTACT_ID }
+data class PersonIdentifier(val type: Identifier, val value: String)
+
+class PersonReference(personIdentifiers: List<PersonIdentifier>) {
+  constructor(nomsNumber: String, dpsContactId: Long) : this(
+    listOf(
+      PersonIdentifier(Identifier.NOMS, nomsNumber),
+      PersonIdentifier(Identifier.DPS_CONTACT_ID, dpsContactId.toString()),
+    ),
+  )
+
+  constructor(dpsContactId: Long) : this(
+    listOf(
+      PersonIdentifier(Identifier.DPS_CONTACT_ID, dpsContactId.toString()),
+    ),
+  )
+
+  @Suppress("MemberVisibilityCanBePrivate")
+  val identifiers: List<PersonIdentifier> = personIdentifiers
+
+  fun nomsNumber(): String? = identifiers.find { it.type == Identifier.NOMS }?.value
+  fun dpsContactId(): String? = identifiers.find { it.type == Identifier.DPS_CONTACT_ID }?.value
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -14,64 +14,64 @@ class OutboundEventsService(
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun send(outboundEvent: OutboundEvent, identifier: Long) {
+  fun send(outboundEvent: OutboundEvent, identifier: Long, contactId: Long, noms: String = "") {
     if (featureSwitches.isEnabled(outboundEvent)) {
-      log.info("Sending outbound event $outboundEvent for identifier $identifier")
+      log.info("Sending outbound event $outboundEvent for identifier $identifier  (contactId $contactId, noms $noms)")
       when (outboundEvent) {
         OutboundEvent.CONTACT_CREATED,
         OutboundEvent.CONTACT_AMENDED,
         OutboundEvent.CONTACT_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactInfo(identifier))
+          sendSafely(outboundEvent, ContactInfo(identifier), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.CONTACT_ADDRESS_CREATED,
         OutboundEvent.CONTACT_ADDRESS_AMENDED,
         OutboundEvent.CONTACT_ADDRESS_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactAddressInfo(identifier))
+          sendSafely(outboundEvent, ContactAddressInfo(identifier), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.CONTACT_PHONE_CREATED,
         OutboundEvent.CONTACT_PHONE_AMENDED,
         OutboundEvent.CONTACT_PHONE_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactPhoneInfo(identifier))
+          sendSafely(outboundEvent, ContactPhoneInfo(identifier), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.CONTACT_EMAIL_CREATED,
         OutboundEvent.CONTACT_EMAIL_AMENDED,
         OutboundEvent.CONTACT_EMAIL_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactEmailInfo(identifier))
+          sendSafely(outboundEvent, ContactEmailInfo(identifier), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.CONTACT_IDENTITY_CREATED,
         OutboundEvent.CONTACT_IDENTITY_AMENDED,
         OutboundEvent.CONTACT_IDENTITY_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactIdentityInfo(identifier))
+          sendSafely(outboundEvent, ContactIdentityInfo(identifier), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.CONTACT_RESTRICTION_CREATED,
         OutboundEvent.CONTACT_RESTRICTION_AMENDED,
         OutboundEvent.CONTACT_RESTRICTION_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactRestrictionInfo(identifier))
+          sendSafely(outboundEvent, ContactRestrictionInfo(identifier), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.PRISONER_CONTACT_CREATED,
         OutboundEvent.PRISONER_CONTACT_AMENDED,
         OutboundEvent.PRISONER_CONTACT_DELETED,
         -> {
-          sendSafely(outboundEvent, PrisonerContactInfo(identifier))
+          sendSafely(outboundEvent, PrisonerContactInfo(identifier), PersonReference(dpsContactId = contactId, nomsNumber = noms))
         }
 
         OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
         OutboundEvent.PRISONER_CONTACT_RESTRICTION_AMENDED,
         OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED,
         -> {
-          sendSafely(outboundEvent, PrisonerContactRestrictionInfo(identifier))
+          sendSafely(outboundEvent, PrisonerContactRestrictionInfo(identifier), PersonReference(dpsContactId = contactId, nomsNumber = noms))
         }
       }
     } else {
@@ -81,12 +81,19 @@ class OutboundEventsService(
 
   private fun sendSafely(
     outboundEvent: OutboundEvent,
-    info: AdditionalInformation,
+    additionalInformation: AdditionalInformation,
+    personReference: PersonReference?,
   ) {
     try {
-      publisher.send(outboundEvent.event(info))
+      publisher.send(outboundEvent.event(additionalInformation, personReference))
     } catch (e: Exception) {
-      log.error("Unable to send event with type {} and info {}", outboundEvent, info, e)
+      log.error(
+        "Unable to send event with type {}, info {}, person {}",
+        outboundEvent,
+        additionalInformation,
+        personReference,
+        e,
+      )
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
@@ -29,7 +29,7 @@ class ContactEmailFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(emailService.create(any(), any())).thenReturn(contactEmailDetails)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = CreateEmailRequest(
       emailAddress = "test@example.com",
       createdBy = "created",
@@ -39,14 +39,14 @@ class ContactEmailFacadeTest {
 
     assertThat(result).isEqualTo(contactEmailDetails)
     verify(emailService).create(contactId, request)
-    verify(eventsService).send(OutboundEvent.CONTACT_EMAIL_CREATED, contactEmailId)
+    verify(eventsService).send(OutboundEvent.CONTACT_EMAIL_CREATED, contactEmailId, contactId)
   }
 
   @Test
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = CreateEmailRequest(
       emailAddress = "test@example.com",
       createdBy = "created",
@@ -58,13 +58,13 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(emailService.update(any(), any(), any())).thenReturn(contactEmailDetails)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = UpdateEmailRequest(
       emailAddress = "test@example.com",
       amendedBy = "amended",
@@ -74,14 +74,14 @@ class ContactEmailFacadeTest {
 
     assertThat(result).isEqualTo(contactEmailDetails)
     verify(emailService).update(contactId, contactEmailId, request)
-    verify(eventsService).send(OutboundEvent.CONTACT_EMAIL_AMENDED, contactEmailId)
+    verify(eventsService).send(OutboundEvent.CONTACT_EMAIL_AMENDED, contactEmailId, contactId)
   }
 
   @Test
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = UpdateEmailRequest(
       emailAddress = "test@example.com",
       amendedBy = "amended",
@@ -93,7 +93,7 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).update(contactId, contactEmailId, request)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -104,7 +104,7 @@ class ContactEmailFacadeTest {
 
     assertThat(result).isEqualTo(contactEmailDetails)
     verify(emailService).get(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -117,25 +117,25 @@ class ContactEmailFacadeTest {
 
     assertThat(exception.message).isEqualTo("Contact email with id (99) not found for contact (11)")
     verify(emailService).get(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(emailService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactEmailId)
 
     verify(emailService).delete(contactId, contactEmailId)
-    verify(eventsService).send(OutboundEvent.CONTACT_EMAIL_DELETED, contactEmailId)
+    verify(eventsService).send(OutboundEvent.CONTACT_EMAIL_DELETED, contactEmailId, contactId)
   }
 
   @Test
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactEmailId)
@@ -143,6 +143,6 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).delete(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacadeTest.kt
@@ -29,7 +29,7 @@ class ContactIdentityFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(identityService.create(any(), any())).thenReturn(contactIdentityDetails)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = CreateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
@@ -40,14 +40,14 @@ class ContactIdentityFacadeTest {
 
     assertThat(result).isEqualTo(contactIdentityDetails)
     verify(identityService).create(contactId, request)
-    verify(eventsService).send(OutboundEvent.CONTACT_IDENTITY_CREATED, contactIdentityId)
+    verify(eventsService).send(OutboundEvent.CONTACT_IDENTITY_CREATED, contactIdentityId, contactId)
   }
 
   @Test
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = CreateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
@@ -60,13 +60,13 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(identityService.update(any(), any(), any())).thenReturn(contactIdentityDetails)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = UpdateIdentityRequest(
       identityType = "PASS",
       identityValue = "P978654312",
@@ -77,14 +77,14 @@ class ContactIdentityFacadeTest {
 
     assertThat(result).isEqualTo(contactIdentityDetails)
     verify(identityService).update(contactId, contactIdentityId, request)
-    verify(eventsService).send(OutboundEvent.CONTACT_IDENTITY_AMENDED, contactIdentityId)
+    verify(eventsService).send(OutboundEvent.CONTACT_IDENTITY_AMENDED, contactIdentityId, contactId)
   }
 
   @Test
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = UpdateIdentityRequest(
       identityType = "PASS",
       identityValue = "P978654312",
@@ -97,7 +97,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).update(contactId, contactIdentityId, request)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -108,7 +108,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(result).isEqualTo(contactIdentityDetails)
     verify(identityService).get(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -121,25 +121,25 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception.message).isEqualTo("Contact identity with id (99) not found for contact (11)")
     verify(identityService).get(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(identityService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactIdentityId)
 
     verify(identityService).delete(contactId, contactIdentityId)
-    verify(eventsService).send(OutboundEvent.CONTACT_IDENTITY_DELETED, contactIdentityId)
+    verify(eventsService).send(OutboundEvent.CONTACT_IDENTITY_DELETED, contactIdentityId, contactId, "")
   }
 
   @Test
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactIdentityId)
@@ -147,6 +147,6 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).delete(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
@@ -28,7 +28,7 @@ class ContactPhoneFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(phoneService.create(any(), any())).thenReturn(contactPhoneDetails)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = CreatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -39,14 +39,14 @@ class ContactPhoneFacadeTest {
 
     assertThat(result).isEqualTo(contactPhoneDetails)
     verify(phoneService).create(contactId, request)
-    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_CREATED, contactPhoneId)
+    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_CREATED, contactPhoneId, contactId)
   }
 
   @Test
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = CreatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -59,13 +59,13 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(phoneService.update(any(), any(), any())).thenReturn(contactPhoneDetails)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = UpdatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -76,14 +76,14 @@ class ContactPhoneFacadeTest {
 
     assertThat(result).isEqualTo(contactPhoneDetails)
     verify(phoneService).update(contactId, contactPhoneId, request)
-    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_AMENDED, contactPhoneId)
+    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_AMENDED, contactPhoneId, contactId)
   }
 
   @Test
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
     val request = UpdatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -96,25 +96,25 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).update(contactId, contactPhoneId, request)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(phoneService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactPhoneId)
 
     verify(phoneService).delete(contactId, contactPhoneId)
-    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_DELETED, contactPhoneId)
+    verify(eventsService).send(OutboundEvent.CONTACT_PHONE_DELETED, contactPhoneId, contactId)
   }
 
   @Test
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactPhoneId)
@@ -122,7 +122,7 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).delete(contactId, contactPhoneId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -133,6 +133,6 @@ class ContactPhoneFacadeTest {
 
     assertThat(result).isEqualTo(contactPhoneDetails)
     verify(phoneService).get(contactId, contactPhoneId)
-    verify(eventsService, never()).send(any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsServiceTest.kt
@@ -27,10 +27,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_CREATED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact.created",
       expectedAdditionalInformation = ContactInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact has been created",
     )
   }
@@ -38,10 +39,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_AMENDED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact.amended",
       expectedAdditionalInformation = ContactInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact has been amended",
     )
   }
@@ -49,10 +51,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_DELETED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact.deleted",
       expectedAdditionalInformation = ContactInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact has been deleted",
     )
   }
@@ -60,10 +63,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_CREATED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-address.created",
       expectedAdditionalInformation = ContactAddressInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been created",
     )
   }
@@ -71,10 +75,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_AMENDED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-address.amended",
       expectedAdditionalInformation = ContactAddressInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been amended",
     )
   }
@@ -82,10 +87,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact address deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_ADDRESS_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_ADDRESS_DELETED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-address.deleted",
       expectedAdditionalInformation = ContactAddressInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact address has been deleted",
     )
   }
@@ -93,10 +99,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact email created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_EMAIL_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_CREATED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-email.created",
       expectedAdditionalInformation = ContactEmailInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact email address has been created",
     )
   }
@@ -104,10 +111,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact email amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_EMAIL_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_AMENDED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-email.amended",
       expectedAdditionalInformation = ContactEmailInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact email address has been amended",
     )
   }
@@ -115,10 +123,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact email deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_EMAIL_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_EMAIL_DELETED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-email.deleted",
       expectedAdditionalInformation = ContactEmailInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact email address has been deleted",
     )
   }
@@ -126,10 +135,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact phone created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_PHONE_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_CREATED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-phone.created",
       expectedAdditionalInformation = ContactPhoneInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact phone number has been created",
     )
   }
@@ -137,10 +147,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact phone amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_PHONE_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_AMENDED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-phone.amended",
       expectedAdditionalInformation = ContactPhoneInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact phone number has been amended",
     )
   }
@@ -148,10 +159,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact phone deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_PHONE_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_PHONE_DELETED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-phone.deleted",
       expectedAdditionalInformation = ContactPhoneInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact phone number has been deleted",
     )
   }
@@ -159,10 +171,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact identity created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_IDENTITY_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_CREATED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-identity.created",
       expectedAdditionalInformation = ContactIdentityInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been created",
     )
   }
@@ -170,10 +183,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact identity amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_IDENTITY_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_AMENDED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-identity.amended",
       expectedAdditionalInformation = ContactIdentityInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been amended",
     )
   }
@@ -181,10 +195,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact identity deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_IDENTITY_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_IDENTITY_DELETED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-identity.deleted",
       expectedAdditionalInformation = ContactIdentityInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact proof of identity has been deleted",
     )
   }
@@ -192,10 +207,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact restriction created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_RESTRICTION_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_CREATED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-restriction.created",
       expectedAdditionalInformation = ContactRestrictionInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact restriction has been created",
     )
   }
@@ -203,10 +219,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact restriction amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_RESTRICTION_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_AMENDED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-restriction.amended",
       expectedAdditionalInformation = ContactRestrictionInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact restriction has been amended",
     )
   }
@@ -214,10 +231,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `contact restriction deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.CONTACT_RESTRICTION_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.CONTACT_RESTRICTION_DELETED, 1L, 1L)
     verify(
       expectedEventType = "contacts-api.contact-restriction.deleted",
       expectedAdditionalInformation = ContactRestrictionInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L),
       expectedDescription = "A contact restriction has been deleted",
     )
   }
@@ -225,10 +243,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_CREATED, 1L, 1L, "A1234AA")
     verify(
       expectedEventType = "contacts-api.prisoner-contact.created",
       expectedAdditionalInformation = PrisonerContactInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been created",
     )
   }
@@ -236,10 +255,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_AMENDED, 1L, 1L, "A1234AA")
     verify(
       expectedEventType = "contacts-api.prisoner-contact.amended",
       expectedAdditionalInformation = PrisonerContactInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been amended",
     )
   }
@@ -247,10 +267,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_DELETED, 1L, 1L, "A1234AA")
     verify(
       expectedEventType = "contacts-api.prisoner-contact.deleted",
       expectedAdditionalInformation = PrisonerContactInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact has been deleted",
     )
   }
@@ -258,10 +279,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact restriction created event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED, 1L)
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED, 1L, 1L, "A1234AA")
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.created",
       expectedAdditionalInformation = PrisonerContactRestrictionInfo(1L),
+      expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been created",
     )
   }
@@ -269,10 +291,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact restriction amended event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_RESTRICTION_AMENDED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_AMENDED, 1L)
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_AMENDED, 1L, 1L, "A1234AA")
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.amended",
       expectedAdditionalInformation = PrisonerContactRestrictionInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been amended",
     )
   }
@@ -280,10 +303,11 @@ class OutboundEventsServiceTest {
   @Test
   fun `prisoner contact resrtiction deleted event with id 1 is sent to the events publisher`() {
     featureSwitches.stub { on { isEnabled(OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED) } doReturn true }
-    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED, 1L)
+    outboundEventsService.send(OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED, 1L, 1L, "A1234AA")
     verify(
       expectedEventType = "contacts-api.prisoner-contact-restriction.deleted",
       expectedAdditionalInformation = PrisonerContactRestrictionInfo(1),
+      expectedPersonReference = PersonReference(dpsContactId = 1L, nomsNumber = "A1234AA"),
       expectedDescription = "A prisoner contact restriction has been deleted",
     )
   }
@@ -291,7 +315,7 @@ class OutboundEventsServiceTest {
   @Test
   fun `events are not published for any outbound event when not enabled`() {
     featureSwitches.stub { on { isEnabled(any<OutboundEvent>(), any()) } doReturn false }
-    OutboundEvent.entries.forEach { outboundEventsService.send(it, 1L) }
+    OutboundEvent.entries.forEach { outboundEventsService.send(it, 1L, 1L) }
     verifyNoInteractions(eventsPublisher)
   }
 
@@ -301,7 +325,7 @@ class OutboundEventsServiceTest {
     featureSwitches.stub { on { isEnabled(event) } doReturn true }
     whenever(eventsPublisher.send(any())).thenThrow(RuntimeException("Boom!"))
 
-    outboundEventsService.send(event, 1L)
+    outboundEventsService.send(event, 1L, 1L)
 
     verify(eventsPublisher).send(any())
   }
@@ -309,6 +333,7 @@ class OutboundEventsServiceTest {
   private fun verify(
     expectedEventType: String,
     expectedAdditionalInformation: AdditionalInformation,
+    expectedPersonReference: PersonReference,
     expectedOccurredAt: LocalDateTime = LocalDateTime.now(),
     expectedDescription: String,
   ) {
@@ -317,6 +342,8 @@ class OutboundEventsServiceTest {
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo(expectedEventType)
       assertThat(additionalInformation).isEqualTo(expectedAdditionalInformation)
+      assertThat(personReference?.dpsContactId()).isEqualTo(expectedPersonReference.dpsContactId())
+      assertThat(personReference?.nomsNumber()).isEqualTo(expectedPersonReference.nomsNumber())
       assertThat(occurredAt).isCloseTo(expectedOccurredAt, within(60, ChronoUnit.SECONDS))
       assertThat(description).isEqualTo(expectedDescription)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
@@ -52,7 +52,7 @@ class ContactFacadeTest {
 
     assertThat(response).isEqualTo(result)
     verify(contactPatchService).patch(contactId, request)
-    verify(outboundEventsService).send(OutboundEvent.CONTACT_AMENDED, contactId)
+    verify(outboundEventsService).send(OutboundEvent.CONTACT_AMENDED, contactId, contactId)
   }
 
   @Test
@@ -68,7 +68,7 @@ class ContactFacadeTest {
     val result = contactFacade.createContact(request)
 
     assertThat(result).isEqualTo(createdContact)
-    verify(outboundEventsService).send(OutboundEvent.CONTACT_CREATED, 98765)
+    verify(outboundEventsService).send(OutboundEvent.CONTACT_CREATED, createdContact.id, createdContact.id)
   }
 
   @Test
@@ -91,8 +91,8 @@ class ContactFacadeTest {
     val result = contactFacade.createContact(request)
 
     assertThat(result).isEqualTo(createdContact)
-    verify(outboundEventsService).send(OutboundEvent.CONTACT_CREATED, 98765)
-    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_CREATED, 123456)
+    verify(outboundEventsService).send(OutboundEvent.CONTACT_CREATED, createdContact.id, createdContact.id)
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_CREATED, 123456, createdContact.id, "A1234BC")
   }
 
   @Test
@@ -113,7 +113,7 @@ class ContactFacadeTest {
 
     contactFacade.addContactRelationship(99, request)
 
-    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_CREATED, prisonerContactId)
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_CREATED, prisonerContactId, 99, "A1234BC")
   }
 
   @Test
@@ -126,7 +126,7 @@ class ContactFacadeTest {
 
     assertThat(contactFacade.searchContacts(pageable, request)).isEqualTo(result)
 
-    verify(outboundEventsService, never()).send(any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -137,7 +137,7 @@ class ContactFacadeTest {
 
     assertThat(contactFacade.getContact(99L)).isEqualTo(expectedContact)
 
-    verify(outboundEventsService, never()).send(any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any())
   }
 
   @Test
@@ -151,7 +151,7 @@ class ContactFacadeTest {
     contactFacade.patchRelationship(contactId, prisonerContactId, request)
 
     verify(contactService).updateContactRelationship(contactId, prisonerContactId, request)
-    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_AMENDED, contactId)
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_CONTACT_AMENDED, prisonerContactId, contactId)
   }
 
   private fun aContactDetails() = ContactDetails(


### PR DESCRIPTION
This PR:
* Allows duplicate PERSON_ID in migrate - if exists, it deletes the old and recreates.
* Avoids a 409 conflict in migrate (but still does not allow duplicate person on sync)
* Adds a source system (DPS or NOMIS) to outbound events - set to DPS for all at present (next PR will change this)
* Adds a personReference attribute to all outbound events