### PR TITLE
PRC-306: Return prisoner contact id on add/create contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/ContactCreationResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/ContactCreationResult.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppscontactsapi.model
-
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
-
-data class ContactCreationResult(val createdContact: ContactDetails, val createdRelationship: Long?)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactCreationResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/ContactCreationResult.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "The result of creating a contact and optionally a new relationship to a prisoner")
+data class ContactCreationResult(
+  @Schema(description = "The details of a contact as an individual")
+  val createdContact: ContactDetails,
+  @Schema(description = "Describes the prisoner contact relationship if one was created with the contact", nullable = true)
+  val createdRelationship: PrisonerContactRelationshipDetails?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipDetails.kt
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Describes the prisoner contact relationship")
 data class PrisonerContactRelationshipDetails(
 
+  @Schema(description = "The unique identifier for the prisoner contact", example = "123456")
+  val prisonerContactId: Long,
+
   @Schema(description = "The relationship code between the prisoner and the contact", example = "FRI")
   val relationshipCode: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -33,8 +33,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContact
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItemPage
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.net.URI
@@ -70,7 +72,7 @@ class ContactController(
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = ContactDetails::class),
+            schema = Schema(implementation = ContactCreationResult::class),
           ),
         ],
       ),
@@ -88,10 +90,10 @@ class ContactController(
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN')")
   fun createContact(@Valid @RequestBody createContactRequest: CreateContactRequest): ResponseEntity<Any> {
-    val createdContact = contactFacade.createContact(createContactRequest)
+    val created = contactFacade.createContact(createContactRequest)
     return ResponseEntity
-      .created(URI.create("/contact/${createdContact.id}"))
-      .body(createdContact)
+      .created(URI.create("/contact/${created.createdContact.id}"))
+      .body(created)
   }
 
   @GetMapping("/{contactId}")
@@ -144,6 +146,12 @@ class ContactController(
       ApiResponse(
         responseCode = "201",
         description = "Created the relationship successfully",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = PrisonerContactRelationshipDetails::class),
+          ),
+        ],
       ),
       ApiResponse(
         responseCode = "400",
@@ -166,8 +174,8 @@ class ContactController(
       example = "123456",
     ) contactId: Long,
     @Valid @RequestBody relationshipRequest: AddContactRelationshipRequest,
-  ) {
-    contactFacade.addContactRelationship(contactId, relationshipRequest)
+  ): PrisonerContactRelationshipDetails {
+    return contactFacade.addContactRelationship(contactId, relationshipRequest)
   }
 
   @GetMapping("/search")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipService.kt
@@ -18,6 +18,7 @@ class PrisonerContactRelationshipService(
 
   fun PrisonerContactSummaryEntity.toRelationshipModel(): PrisonerContactRelationshipDetails {
     return PrisonerContactRelationshipDetails(
+      prisonerContactId = this.prisonerContactId,
       relationshipCode = this.relationshipType,
       relationshipDescription = this.relationshipDescription ?: "",
       nextOfKin = this.nextOfKin,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactIdentityDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -267,4 +268,22 @@ fun createContactIdentityDetails(
   createdTime,
   amendedBy,
   amendedTime,
+)
+
+fun createPrisonerContactRelationshipDetails(
+  id: Long = 1,
+  relationshipCode: String = "FRI",
+  relationshipDescription: String = "Friend",
+  emergencyContact: Boolean = false,
+  nextOfKin: Boolean = false,
+  isRelationshipActive: Boolean = true,
+  comments: String? = null,
+) = PrisonerContactRelationshipDetails(
+  id,
+  relationshipCode,
+  relationshipDescription,
+  emergencyContact,
+  nextOfKin,
+  isRelationshipActive,
+  comments,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -15,11 +15,13 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateContactRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.patch.PatchContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmailDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactIdentityDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactSearchResultItem
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateContactResponse
@@ -40,7 +42,23 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .isCreated
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectHeader().valuesMatch("Location", "/contact/(\\d)+")
-      .expectBody(ContactDetails::class.java)
+      .expectBody(ContactCreationResult::class.java)
+      .returnResult().responseBody!!.createdContact
+  }
+
+  fun createAContactWithARelationship(request: CreateContactRequest): ContactCreationResult {
+    return webTestClient.post()
+      .uri("/contact")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(authorised())
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isCreated
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectHeader().valuesMatch("Location", "/contact/(\\d)+")
+      .expectBody(ContactCreationResult::class.java)
       .returnResult().responseBody!!
   }
 
@@ -94,8 +112,8 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .returnResult().responseBody
   }
 
-  fun addAContactRelationship(contactId: Long, request: AddContactRelationshipRequest) {
-    webTestClient.post()
+  fun addAContactRelationship(contactId: Long, request: AddContactRelationshipRequest): PrisonerContactRelationshipDetails {
+    return webTestClient.post()
       .uri("/contact/$contactId/relationship")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
@@ -104,6 +122,9 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .exchange()
       .expectStatus()
       .isCreated
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(PrisonerContactRelationshipDetails::class.java)
+      .returnResult().responseBody!!
   }
 
   fun getSearchContactResults(uri: URI) = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -154,10 +154,8 @@ class AddContactRelationshipIntegrationTest : H2IntegrationTestBase() {
       createdBy = "USER",
     )
 
-    testAPIClient.addAContactRelationship(contact.id, request)
+    val createdRelationship = testAPIClient.addAContactRelationship(contact.id, request)
 
-    val contacts = testAPIClient.getPrisonerContacts("A1234BC").content
-    val createdRelationship = contacts.find { it.firstName == contact.firstName && it.lastName == contact.lastName }!!
     assertThat(createdRelationship.relationshipCode).isEqualTo("MOT")
     assertThat(createdRelationship.relationshipDescription).isEqualTo("Mother")
     assertThat(createdRelationship.nextOfKin).isTrue()
@@ -181,10 +179,7 @@ class AddContactRelationshipIntegrationTest : H2IntegrationTestBase() {
       createdBy = "USER",
     )
 
-    testAPIClient.addAContactRelationship(contact.id, request)
-
-    val contacts = testAPIClient.getPrisonerContacts("A1234BC").content
-    val createdRelationship = contacts.find { it.firstName == contact.firstName && it.lastName == contact.lastName }!!
+    val createdRelationship = testAPIClient.addAContactRelationship(contact.id, request)
     assertThat(createdRelationship.relationshipCode).isEqualTo("MOT")
     assertThat(createdRelationship.relationshipDescription).isEqualTo("Mother")
     assertThat(createdRelationship.nextOfKin).isFalse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearchapi.mo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.H2IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.ContactRelationship
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactRelationshipDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactInfo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PrisonerContactInfo
@@ -97,17 +97,13 @@ class CreateContactWithRelationshipIntegrationTest : H2IntegrationTestBase() {
       relationship = requestedRelationship,
     )
 
-    testAPIClient.createAContact(request)
+    val created = testAPIClient.createAContactWithARelationship(request)
 
-    val prisonerContacts = testAPIClient.getPrisonerContacts(prisonerNumber).content
-    assertThat(prisonerContacts).hasSize(1)
+    assertThat(created.createdContact.lastName).isEqualTo(request.lastName)
+    asserPrisonerContactEquals(created.createdRelationship!!, requestedRelationship)
 
-    val prisonerContact = prisonerContacts[0]
-    assertThat(prisonerContact.lastName).isEqualTo(request.lastName)
-    asserPrisonerContactEquals(prisonerContact, requestedRelationship)
-
-    stubEvents.assertHasEvent(OutboundEvent.CONTACT_CREATED, ContactInfo(prisonerContact.contactId))
-    stubEvents.assertHasEvent(OutboundEvent.PRISONER_CONTACT_CREATED, PrisonerContactInfo(prisonerContact.prisonerContactId))
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_CREATED, ContactInfo(created.createdContact.id))
+    stubEvents.assertHasEvent(OutboundEvent.PRISONER_CONTACT_CREATED, PrisonerContactInfo(created.createdRelationship!!.prisonerContactId))
   }
 
   @Test
@@ -128,19 +124,16 @@ class CreateContactWithRelationshipIntegrationTest : H2IntegrationTestBase() {
       relationship = requestedRelationship,
     )
 
-    testAPIClient.createAContact(request)
-    val prisonerContacts = testAPIClient.getPrisonerContacts(prisonerNumber).content
-    assertThat(prisonerContacts).hasSize(1)
+    val created = testAPIClient.createAContactWithARelationship(request)
 
-    val prisonerContact = prisonerContacts[0]
-    assertThat(prisonerContact.lastName).isEqualTo(request.lastName)
-    asserPrisonerContactEquals(prisonerContact, requestedRelationship)
-    stubEvents.assertHasEvent(OutboundEvent.CONTACT_CREATED, ContactInfo(prisonerContact.contactId))
-    stubEvents.assertHasEvent(OutboundEvent.PRISONER_CONTACT_CREATED, PrisonerContactInfo(prisonerContact.prisonerContactId))
+    assertThat(created.createdContact.lastName).isEqualTo(request.lastName)
+    asserPrisonerContactEquals(created.createdRelationship!!, requestedRelationship)
+    stubEvents.assertHasEvent(OutboundEvent.CONTACT_CREATED, ContactInfo(created.createdContact.id))
+    stubEvents.assertHasEvent(OutboundEvent.PRISONER_CONTACT_CREATED, PrisonerContactInfo(created.createdRelationship!!.prisonerContactId))
   }
 
   private fun asserPrisonerContactEquals(
-    prisonerContact: PrisonerContactSummary,
+    prisonerContact: PrisonerContactRelationshipDetails,
     relationship: ContactRelationship,
   ) {
     with(prisonerContact) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsRelationshipIntegrationTest.kt
@@ -55,6 +55,7 @@ class GetPrisonerContactsRelationshipIntegrationTest : H2IntegrationTestBase() {
   @Test
   fun `should return OK`() {
     val expectedPrisonerContactRelationship = PrisonerContactRelationshipDetails(
+      prisonerContactId = 1,
       relationshipCode = "FA",
       relationshipDescription = "Father",
       nextOfKin = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactRelationshipControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactRelationshipControllerTest.kt
@@ -41,6 +41,7 @@ class PrisonerContactRelationshipControllerTest {
   }
 
   private fun getMockPrisonerContactRelationship() = PrisonerContactRelationshipDetails(
+    prisonerContactId = 1,
     relationshipCode = "FRI",
     relationshipDescription = "Friend",
     nextOfKin = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -209,6 +209,9 @@ class ContactServiceTest {
       )
       whenever(contactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
       whenever(prisonerContactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
+      whenever(referenceCodeService.getReferenceDataByGroupAndCode("RELATIONSHIP", "FRI")).thenReturn(
+        ReferenceCode(1, "RELATIONSHIP", "FRI", "Friend", 1, true),
+      )
 
       service.createContact(request)
 
@@ -550,6 +553,9 @@ class ContactServiceTest {
       )
       whenever(contactRepository.findById(id)).thenReturn(Optional.of(contact))
       whenever(prisonerContactRepository.saveAndFlush(any())).thenAnswer { i -> i.arguments[0] }
+      whenever(referenceCodeService.getReferenceDataByGroupAndCode("RELATIONSHIP", "MOT")).thenReturn(
+        ReferenceCode(1, "RELATIONSHIP", "MOT", "Mother", 1, true),
+      )
 
       service.addContactRelationship(id, request)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipServiceTest.kt
@@ -41,6 +41,7 @@ class PrisonerContactRelationshipServiceTest {
   fun `should return when prisoner contact relationship exists`() {
     val prisonerContactId = 1L
     val expectedPrisonerContactRelationship = PrisonerContactRelationshipDetails(
+      prisonerContactId = prisonerContactId,
       relationshipCode = "FRIEND",
       relationshipDescription = "Friend",
       nextOfKin = false,


### PR DESCRIPTION
This is required to be able to link into journeys after creation was successful.