### PR TITLE
PRC-310: Fix (attempted) for missing source on events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -236,9 +236,7 @@ enum class OutboundEvent(val eventType: String) {
  * This is inherited and expanded individually for each event type.
  */
 
-abstract class AdditionalInformation {
-  protected abstract val source: Source
-}
+open class AdditionalInformation(open val source: Source)
 
 /**
  * The class representing outbound domain events
@@ -258,14 +256,14 @@ data class OutboundHMPPSDomainEvent(
  * The additional information is mapped into JSON by the ObjectMapper as part of the event body.
  */
 
-data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
-data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation()
+data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class PrisonerContactInfo(val prisonerContactId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class PrisonerContactRestrictionInfo(val prisonerContactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 
 /**
  * The event source.
@@ -315,4 +313,6 @@ class PersonReference(personIdentifiers: List<PersonIdentifier>) {
 
     return identifiers == other.identifiers
   }
+
+  override fun toString(): String = this.identifiers.toString()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/AddContactRelationshipIntegrationTest.kt
@@ -163,6 +163,7 @@ class AddContactRelationshipIntegrationTest : H2IntegrationTestBase() {
     assertThat(createdRelationship.nextOfKin).isTrue()
     assertThat(createdRelationship.emergencyContact).isFalse()
     assertThat(createdRelationship.comments).isNull()
+
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
       additionalInfo = PrisonerContactInfo(createdRelationship.prisonerContactId, source = Source.DPS),
@@ -191,6 +192,7 @@ class AddContactRelationshipIntegrationTest : H2IntegrationTestBase() {
     assertThat(createdRelationship.nextOfKin).isFalse()
     assertThat(createdRelationship.emergencyContact).isTrue()
     assertThat(createdRelationship.comments).isEqualTo("Some comments")
+
     stubEvents.assertHasEvent(
       event = OutboundEvent.PRISONER_CONTACT_CREATED,
       additionalInfo = PrisonerContactInfo(createdRelationship.prisonerContactId, source = Source.DPS),

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,5 +34,6 @@ feature:
       contact:
         created: true
         amended: true
+        deleted: true
       prisoner-contact:
         created: true


### PR DESCRIPTION
Its to do with data classes inheriting from a parent class, and the parent class attributes not being visible to the ObjectMapper.