### PR TITLE
PRC-310: More sync events and corrections for handling prisoner contact restrictions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -273,19 +273,34 @@ class SyncFacade(
   fun createContactAddress(request: SyncCreateContactAddressRequest) =
     syncContactAddressService.createContactAddress(request)
       .also {
-        logger.info("TODO - Create contact address domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_ADDRESS_CREATED,
+          identifier = it.contactAddressId,
+          contactId = it.contactId,
+          source = Source.NOMIS,
+        )
       }
 
   fun updateContactAddress(contactAddressId: Long, request: SyncUpdateContactAddressRequest) =
     syncContactAddressService.updateContactAddress(contactAddressId, request)
       .also {
-        logger.info("TODO - Update contact address domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+          identifier = it.contactAddressId,
+          contactId = it.contactId,
+          source = Source.NOMIS,
+        )
       }
 
   fun deleteContactAddress(contactAddressId: Long) =
     syncContactAddressService.deleteContactAddress(contactAddressId)
       .also {
-        logger.info("TODO - Delete contact address domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_ADDRESS_DELETED,
+          identifier = it.contactAddressId,
+          contactId = it.contactId,
+          source = Source.NOMIS,
+        )
       }
 
   // ================================================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -356,18 +356,36 @@ class SyncFacade(
   fun createPrisonerContactRestriction(request: SyncCreatePrisonerContactRestrictionRequest) =
     syncPrisonerContactRestrictionService.createPrisonerContactRestriction(request)
       .also {
-        logger.info("TODO - Create prisoner contact restriction domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_CREATED,
+          identifier = it.prisonerContactRestrictionId,
+          contactId = it.contactId,
+          noms = it.prisonerNumber,
+          source = Source.NOMIS,
+        )
       }
 
   fun updatePrisonerContactRestriction(prisonerContactRestrictionId: Long, request: SyncUpdatePrisonerContactRestrictionRequest) =
     syncPrisonerContactRestrictionService.updatePrisonerContactRestriction(prisonerContactRestrictionId, request)
       .also {
-        logger.info("TODO - Update prisoner contact restriction domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_UPDATED,
+          identifier = it.prisonerContactRestrictionId,
+          contactId = it.contactId,
+          noms = it.prisonerNumber,
+          source = Source.NOMIS,
+        )
       }
 
   fun deletePrisonerContactRestriction(prisonerContactRestrictionId: Long) =
     syncPrisonerContactRestrictionService.deletePrisonerContactRestriction(prisonerContactRestrictionId)
       .also {
-        logger.info("TODO - Delete prisoner contact restriction domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.PRISONER_CONTACT_RESTRICTION_DELETED,
+          identifier = it.prisonerContactRestrictionId,
+          contactId = it.contactId,
+          noms = it.prisonerNumber,
+          source = Source.NOMIS,
+        )
       }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -233,19 +233,34 @@ class SyncFacade(
   fun createContactRestriction(request: SyncCreateContactRestrictionRequest) =
     syncContactRestrictionService.createContactRestriction(request)
       .also {
-        logger.info("TODO - Create contact restriction domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_RESTRICTION_CREATED,
+          identifier = it.contactRestrictionId,
+          contactId = it.contactId,
+          source = Source.NOMIS,
+        )
       }
 
   fun updateContactRestriction(contactRestrictionId: Long, request: SyncUpdateContactRestrictionRequest) =
     syncContactRestrictionService.updateContactRestriction(contactRestrictionId, request)
       .also {
-        logger.info("TODO - Update contact restriction domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_RESTRICTION_UPDATED,
+          identifier = it.contactRestrictionId,
+          contactId = it.contactId,
+          source = Source.NOMIS,
+        )
       }
 
   fun deleteContactRestriction(contactRestrictionId: Long) =
     syncContactRestrictionService.deleteContactRestriction(contactRestrictionId)
       .also {
-        logger.info("TODO - Delete contact restriction domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.CONTACT_RESTRICTION_DELETED,
+          identifier = it.contactRestrictionId,
+          contactId = it.contactId,
+          source = Source.NOMIS,
+        )
       }
 
   // ================================================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -313,19 +313,37 @@ class SyncFacade(
   fun createPrisonerContact(request: SyncCreatePrisonerContactRequest) =
     syncPrisonerContactService.createPrisonerContact(request)
       .also {
-        logger.info("TODO - Create prisoner contact domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.PRISONER_CONTACT_CREATED,
+          identifier = it.id,
+          contactId = it.contactId,
+          noms = it.prisonerNumber,
+          source = Source.NOMIS,
+        )
       }
 
   fun updatePrisonerContact(prisonerContactId: Long, request: SyncUpdatePrisonerContactRequest) =
     syncPrisonerContactService.updatePrisonerContact(prisonerContactId, request)
       .also {
-        logger.info("TODO - Update prisoner contact domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.PRISONER_CONTACT_UPDATED,
+          identifier = it.id,
+          contactId = it.contactId,
+          noms = it.prisonerNumber,
+          source = Source.NOMIS,
+        )
       }
 
   fun deletePrisonerContact(prisonerContactId: Long) =
     syncPrisonerContactService.deletePrisonerContact(prisonerContactId)
       .also {
-        logger.info("TODO - Delete prisoner contact domain event")
+        outboundEventsService.send(
+          outboundEvent = OutboundEvent.PRISONER_CONTACT_DELETED,
+          identifier = it.id,
+          contactId = it.contactId,
+          noms = it.prisonerNumber,
+          source = Source.NOMIS,
+        )
       }
 
   // ================================================================

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/sync/PrisonerContactRestrictionEntityMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/mapping/sync/PrisonerContactRestrictionEntityMappers.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 fun SyncCreatePrisonerContactRestrictionRequest.toEntity(): PrisonerContactRestrictionEntity {
   return PrisonerContactRestrictionEntity(
     prisonerContactRestrictionId = 0L,
-    prisonerContactId = this.contactId,
+    prisonerContactId = this.prisonerContactId,
     restrictionType = this.restrictionType,
     startDate = this.startDate,
     expiryDate = this.expiryDate,
@@ -20,10 +20,15 @@ fun SyncCreatePrisonerContactRestrictionRequest.toEntity(): PrisonerContactRestr
   )
 }
 
-fun PrisonerContactRestrictionEntity.toResponse(): SyncPrisonerContactRestriction {
+fun PrisonerContactRestrictionEntity.toResponse(
+  contactId: Long,
+  prisonerNumber: String,
+): SyncPrisonerContactRestriction {
   return SyncPrisonerContactRestriction(
     prisonerContactRestrictionId = this.prisonerContactRestrictionId,
-    contactId = this.prisonerContactId,
+    prisonerContactId = this.prisonerContactId,
+    contactId = contactId,
+    prisonerNumber = prisonerNumber,
     restrictionType = this.restrictionType,
     startDate = this.startDate,
     expiryDate = this.expiryDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncCreatePrisonerContactRestrictionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncCreatePrisonerContactRestrictionRequest.kt
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-@Schema(description = "Request object to create a prisoner contact request details")
+@Schema(description = "Request object to create a prisoner contact restriction")
 data class SyncCreatePrisonerContactRestrictionRequest(
 
-  @Schema(description = "ID of the contact to which the restriction applies", example = "12345")
-  val contactId: Long,
+  @Schema(description = "ID of the prisoner contact (relationship) on which the restriction applies", example = "12345")
+  val prisonerContactId: Long,
 
   @Schema(description = "Type of restriction applied", example = "NoContact")
   val restrictionType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncUpdatePrisonerContactRestrictionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncUpdatePrisonerContactRestrictionRequest.kt
@@ -4,11 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-@Schema(description = "Request object to update prisoner contact restriction details")
+@Schema(description = "Request object to update te  prisoner contact restriction details")
 data class SyncUpdatePrisonerContactRestrictionRequest(
-
-  @Schema(description = "ID of the contact to which the restriction applies", example = "12345")
-  val contactId: Long,
 
   @Schema(description = "Type of restriction applied", example = "NoContact")
   val restrictionType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncPrisonerContactRestriction.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncPrisonerContactRestriction.kt
@@ -7,11 +7,17 @@ import java.time.LocalDateTime
 @Schema(description = "Response object with prisoner contact restriction details")
 data class SyncPrisonerContactRestriction(
 
-  @Schema(description = "ID of the prisoner contact restriction to which the restriction applies", example = "232")
+  @Schema(description = "ID of the prisoner contact restriction", example = "232")
   val prisonerContactRestrictionId: Long,
 
-  @Schema(description = "ID of the contact to which the restriction applies", example = "12345")
+  @Schema(description = "ID of the prisoner contact (relationship) to which the restriction applies", example = "12345")
+  val prisonerContactId: Long,
+
+  @Schema(description = "ID of the contact (person) to which the restriction applies", example = "12345")
   val contactId: Long,
+
+  @Schema(description = "The prisoner number involved in this relationship restriction", example = "A1234AA")
+  val prisonerNumber: String,
 
   @Schema(
     description =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactRestrictionSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactRestrictionSyncController.kt
@@ -156,7 +156,7 @@ class PrisonerContactRestrictionSyncController(
       ),
       ApiResponse(
         responseCode = "404",
-        description = "Prisoner contact restriction not found",
+        description = "Prisoner contact restriction or relationship was not found",
       ),
       ApiResponse(
         responseCode = "400",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactAddressService.kt
@@ -46,12 +46,6 @@ class SyncContactAddressService(
     return contactAddress.toModel()
   }
 
-  fun deleteContactAddress(contactAddressId: Long) {
-    contactAddressRepository.findById(contactAddressId)
-      .orElseThrow { EntityNotFoundException("Contact address with ID $contactAddressId not found") }
-    contactAddressRepository.deleteById(contactAddressId)
-  }
-
   fun createContactAddress(request: SyncCreateContactAddressRequest): SyncContactAddress {
     contactRepository.findById(request.contactId)
       .orElseThrow { EntityNotFoundException("Contact with ID ${request.contactId} not found") }
@@ -97,5 +91,13 @@ class SyncContactAddressService(
     }
 
     return contactAddressRepository.saveAndFlush(changedContactAddress).toModel()
+  }
+
+  // TODO: Should this delete the contact_phone rows that are specifically associated with this address?
+  fun deleteContactAddress(contactAddressId: Long): SyncContactAddress {
+    val rowToDelete = contactAddressRepository.findById(contactAddressId)
+      .orElseThrow { EntityNotFoundException("Contact address with ID $contactAddressId not found") }
+    contactAddressRepository.deleteById(contactAddressId)
+    return rowToDelete.toModel()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactRestrictionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncContactRestrictionService.kt
@@ -31,12 +31,6 @@ class SyncContactRestrictionService(
     return contactRestrictionEntity.toModel()
   }
 
-  fun deleteContactRestriction(contactRestrictionId: Long) {
-    contactRestrictionRepository.findById(contactRestrictionId)
-      .orElseThrow { EntityNotFoundException("Contact restriction with ID $contactRestrictionId not found") }
-    contactRestrictionRepository.deleteById(contactRestrictionId)
-  }
-
   fun createContactRestriction(request: SyncCreateContactRestrictionRequest): SyncContactRestriction {
     contactRepository.findById(request.contactId)
       .orElseThrow { EntityNotFoundException("Contact with ID ${request.contactId} not found") }
@@ -67,5 +61,12 @@ class SyncContactRestrictionService(
     }
 
     return contactRestrictionRepository.saveAndFlush(changedContactRestriction).toModel()
+  }
+
+  fun deleteContactRestriction(contactRestrictionId: Long): SyncContactRestriction {
+    val rowToDelete = contactRestrictionRepository.findById(contactRestrictionId)
+      .orElseThrow { EntityNotFoundException("Contact restriction with ID $contactRestrictionId not found") }
+    contactRestrictionRepository.deleteById(contactRestrictionId)
+    return rowToDelete.toModel()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactRestrictionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactRestrictionService.kt
@@ -8,37 +8,44 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.sync.toResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPrisonerContactRestriction
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRestrictionRepository
 
 @Service
 @Transactional
 class SyncPrisonerContactRestrictionService(
   val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository,
+  val prisonerContactRepository: PrisonerContactRepository,
 ) {
 
   @Transactional(readOnly = true)
   fun getPrisonerContactRestrictionById(prisonerContactRestrictionId: Long): SyncPrisonerContactRestriction {
-    val contactEntity = prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
+    val restriction = prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
       .orElseThrow { EntityNotFoundException("Prisoner contact restriction with ID $prisonerContactRestrictionId not found") }
-    return contactEntity.toResponse()
-  }
 
-  fun deletePrisonerContactRestriction(prisonerContactRestrictionId: Long) {
-    prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
-      .orElseThrow { EntityNotFoundException("Prisoner contact restriction with ID $prisonerContactRestrictionId not found") }
-    prisonerContactRestrictionRepository.deleteById(prisonerContactRestrictionId)
+    val relationship = prisonerContactRepository.findById(restriction.prisonerContactId)
+      .orElseThrow { EntityNotFoundException("Prisoner contact with ID ${restriction.prisonerContactId} not found") }
+
+    return restriction.toResponse(relationship.contactId, relationship.prisonerNumber)
   }
 
   fun createPrisonerContactRestriction(request: SyncCreatePrisonerContactRestrictionRequest): SyncPrisonerContactRestriction {
-    return prisonerContactRestrictionRepository.saveAndFlush(request.toEntity()).toResponse()
+    val relationship = prisonerContactRepository.findById(request.prisonerContactId)
+      .orElseThrow { EntityNotFoundException("Prisoner contact with ID ${request.prisonerContactId} not found") }
+
+    return prisonerContactRestrictionRepository
+      .saveAndFlush(request.toEntity())
+      .toResponse(relationship.contactId, relationship.prisonerNumber)
   }
 
   fun updatePrisonerContactRestriction(prisonerContactRestrictionId: Long, request: SyncUpdatePrisonerContactRestrictionRequest): SyncPrisonerContactRestriction {
-    val contact = prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
+    val restriction = prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
       .orElseThrow { EntityNotFoundException("Prisoner contact restriction with ID $prisonerContactRestrictionId not found") }
 
-    val changedPrisonerContactRestriction = contact.copy(
-      prisonerContactId = request.contactId,
+    val relationship = prisonerContactRepository.findById(restriction.prisonerContactId)
+      .orElseThrow { EntityNotFoundException("Prisoner contact with ID ${restriction.prisonerContactId} not found") }
+
+    val changedPrisonerContactRestriction = restriction.copy(
       restrictionType = request.restrictionType,
       startDate = request.startDate,
       expiryDate = request.expiryDate,
@@ -50,6 +57,20 @@ class SyncPrisonerContactRestrictionService(
       it.amendedTime = request.updatedTime
     }
 
-    return prisonerContactRestrictionRepository.saveAndFlush(changedPrisonerContactRestriction).toResponse()
+    return prisonerContactRestrictionRepository
+      .saveAndFlush(changedPrisonerContactRestriction)
+      .toResponse(relationship.contactId, relationship.prisonerNumber)
+  }
+
+  fun deletePrisonerContactRestriction(prisonerContactRestrictionId: Long): SyncPrisonerContactRestriction {
+    val rowToDelete = prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
+      .orElseThrow { EntityNotFoundException("Prisoner contact restriction with ID $prisonerContactRestrictionId not found") }
+
+    val relationship = prisonerContactRepository.findById(rowToDelete.prisonerContactId)
+      .orElseThrow { EntityNotFoundException("Prisoner contact with ID ${rowToDelete.prisonerContactId} not found") }
+
+    prisonerContactRestrictionRepository.deleteById(prisonerContactRestrictionId)
+
+    return rowToDelete.toResponse(relationship.contactId, relationship.prisonerNumber)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactService.kt
@@ -23,12 +23,6 @@ class SyncPrisonerContactService(
     return contactEntity.toResponse()
   }
 
-  fun deletePrisonerContact(prisonerContactId: Long) {
-    prisonerContactRepository.findById(prisonerContactId)
-      .orElseThrow { EntityNotFoundException("Prisoner contact with ID $prisonerContactId not found") }
-    prisonerContactRepository.deleteById(prisonerContactId)
-  }
-
   fun createPrisonerContact(request: SyncCreatePrisonerContactRequest): SyncPrisonerContact {
     return prisonerContactRepository.saveAndFlush(request.toEntity()).toResponse()
   }
@@ -58,5 +52,12 @@ class SyncPrisonerContactService(
     }
 
     return prisonerContactRepository.saveAndFlush(changedPrisonerContact).toResponse()
+  }
+
+  fun deletePrisonerContact(prisonerContactId: Long): SyncPrisonerContact {
+    val rowToDelete = prisonerContactRepository.findById(prisonerContactId)
+      .orElseThrow { EntityNotFoundException("Prisoner contact with ID $prisonerContactId not found") }
+    prisonerContactRepository.deleteById(prisonerContactId)
+    return rowToDelete.toResponse()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactRestrictionEntityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/sync/SyncPrisonerContactRestrictionEntityIntegrationTest.kt
@@ -247,7 +247,6 @@ class SyncPrisonerContactRestrictionEntityIntegrationTest : H2IntegrationTestBas
 
     private fun updatePrisonerContactRestrictionRequest() =
       SyncUpdatePrisonerContactRestrictionRequest(
-        contactId = 1L,
         restrictionType = "PREINF",
         startDate = LocalDate.of(2024, 1, 1),
         expiryDate = LocalDate.of(2024, 12, 31),
@@ -261,7 +260,7 @@ class SyncPrisonerContactRestrictionEntityIntegrationTest : H2IntegrationTestBas
 
     private fun createPrisonerContactRestrictionRequest() =
       SyncCreatePrisonerContactRestrictionRequest(
-        contactId = 1L,
+        prisonerContactId = 1L,
         restrictionType = "PREINF",
         startDate = LocalDate.of(2024, 1, 1),
         expiryDate = LocalDate.of(2024, 12, 31),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactRestrictionEntityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/sync/SyncPrisonerContactRestrictionEntityServiceTest.kt
@@ -6,36 +6,48 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactRestrictionEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.mapping.sync.toEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncCreatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpdatePrisonerContactRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactRestrictionRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.Optional
 
 class SyncPrisonerContactRestrictionEntityServiceTest {
   private val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository = mock()
-  private val syncService = SyncPrisonerContactRestrictionService(prisonerContactRestrictionRepository)
+  private val prisonerContactRepository: PrisonerContactRepository = mock()
+
+  private val syncService = SyncPrisonerContactRestrictionService(
+    prisonerContactRestrictionRepository,
+    prisonerContactRepository,
+  )
 
   @Nested
   inner class PrisonerContactRestrictionEntityTests {
     @Test
     fun `should get a prisoner contact by ID`() {
-      whenever(prisonerContactRestrictionRepository.findById(1L)).thenReturn(
-        Optional.of(
-          contactEntity(),
-        ),
-      )
-      val prisonerContactRestriction = syncService.getPrisonerContactRestrictionById(1L)
+      whenever(prisonerContactRestrictionRepository.findById(3L))
+        .thenReturn(Optional.of(prisonerContactRestrictionEntity()))
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
+
+      val prisonerContactRestriction = syncService.getPrisonerContactRestrictionById(3L)
+
       with(prisonerContactRestriction) {
-        assertThat(prisonerContactRestrictionId).isEqualTo(1L)
-        assertThat(contactId).isEqualTo(12345L)
+        assertThat(prisonerContactRestrictionId).isEqualTo(3L)
+        assertThat(prisonerContactId).isEqualTo(2L)
+        assertThat(contactId).isEqualTo(1L)
+        assertThat(prisonerNumber).isEqualTo("A1234AA")
         assertThat(restrictionType).isEqualTo("NONCON")
         assertThat(startDate).isEqualTo(LocalDate.of(2024, 1, 1))
         assertThat(expiryDate).isEqualTo(LocalDate.of(2024, 12, 31))
@@ -47,32 +59,45 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
         assertThat(updatedBy).isEqualTo("editor")
         assertThat(updatedTime).isAfter(LocalDateTime.now().minusMinutes(5))
       }
-      verify(prisonerContactRestrictionRepository).findById(1L)
+
+      verify(prisonerContactRestrictionRepository).findById(3L)
+      verify(prisonerContactRepository).findById(2L)
     }
 
     @Test
     fun `should fail to get a prisoner contact restriction by ID when not found`() {
-      whenever(prisonerContactRestrictionRepository.findById(1L)).thenReturn(Optional.empty())
+      whenever(prisonerContactRestrictionRepository.findById(3L))
+        .thenReturn(Optional.empty())
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
+
       assertThrows<EntityNotFoundException> {
-        syncService.getPrisonerContactRestrictionById(1L)
+        syncService.getPrisonerContactRestrictionById(3L)
       }
-      verify(prisonerContactRestrictionRepository).findById(1L)
+
+      verify(prisonerContactRestrictionRepository).findById(3L)
     }
 
     @Test
     fun `should create a prisoner contact restriction`() {
       val request = createPrisonerContactRestrictionRequest()
-      whenever(prisonerContactRestrictionRepository.saveAndFlush(request.toEntity())).thenReturn(contactEntity(null, null))
+
+      whenever(prisonerContactRestrictionRepository.saveAndFlush(request.toEntity()))
+        .thenReturn(prisonerContactRestrictionEntity(null, null))
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
 
       val contact = syncService.createPrisonerContactRestriction(request)
+
       val contactCaptor = argumentCaptor<PrisonerContactRestrictionEntity>()
 
       verify(prisonerContactRestrictionRepository).saveAndFlush(contactCaptor.capture())
 
-      // Checks the entity saved
       with(contactCaptor.firstValue) {
         assertThat(prisonerContactRestrictionId).isEqualTo(0L)
-        assertThat(prisonerContactId).isEqualTo(12345L)
+        assertThat(prisonerContactId).isEqualTo(2L)
         assertThat(restrictionType).isEqualTo("NONCON")
         assertThat(startDate).isEqualTo(LocalDate.of(2024, 1, 1))
         assertThat(expiryDate).isEqualTo(LocalDate.of(2024, 12, 31))
@@ -85,10 +110,11 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
         assertThat(amendedTime).isNull()
       }
 
-      // Checks the model response
       with(contact) {
         assertThat(prisonerContactRestrictionId).isGreaterThan(0)
-        assertThat(contactId).isEqualTo(12345L)
+        assertThat(prisonerContactId).isEqualTo(2L)
+        assertThat(prisonerNumber).isEqualTo("A1234AA")
+        assertThat(contactId).isEqualTo(1L)
         assertThat(restrictionType).isEqualTo("NONCON")
         assertThat(startDate).isEqualTo(LocalDate.of(2024, 1, 1))
         assertThat(expiryDate).isEqualTo(LocalDate.of(2024, 12, 31))
@@ -104,45 +130,58 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
 
     @Test
     fun `should delete prisoner contact restriction by ID`() {
-      whenever(prisonerContactRestrictionRepository.findById(1L)).thenReturn(
-        Optional.of(
-          contactEntity(),
-        ),
-      )
-      syncService.deletePrisonerContactRestriction(1L)
-      verify(prisonerContactRestrictionRepository).deleteById(1L)
+      whenever(prisonerContactRestrictionRepository.findById(3L))
+        .thenReturn(Optional.of(prisonerContactRestrictionEntity()))
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
+
+      syncService.deletePrisonerContactRestriction(3L)
+
+      verify(prisonerContactRestrictionRepository).deleteById(3L)
+      verify(prisonerContactRepository).findById(2L)
     }
 
     @Test
     fun `should fail to delete prisoner contact restriction by ID when not found`() {
-      whenever(prisonerContactRestrictionRepository.findById(1L)).thenReturn(Optional.empty())
+      whenever(prisonerContactRestrictionRepository.findById(3L))
+        .thenReturn(Optional.empty())
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
+
       assertThrows<EntityNotFoundException> {
-        syncService.deletePrisonerContactRestriction(1L)
+        syncService.deletePrisonerContactRestriction(3L)
       }
-      verify(prisonerContactRestrictionRepository).findById(1L)
+
+      verify(prisonerContactRestrictionRepository).findById(3L)
+      verify(prisonerContactRepository, never()).findById(2L)
     }
 
     @Test
     fun `should update a prisoner contact restriction by ID`() {
       val request = updatePrisonerContactRestrictionRequest()
-      val prisonerContactRestrictionID = 1L
-      whenever(prisonerContactRestrictionRepository.findById(prisonerContactRestrictionID)).thenReturn(
-        Optional.of(
-          contactEntity(),
-        ),
-      )
-      whenever(prisonerContactRestrictionRepository.saveAndFlush(any())).thenReturn(request.toEntity())
+      val prisonerContactRestrictionId = 3L
 
-      val updated = syncService.updatePrisonerContactRestriction(prisonerContactRestrictionID, request)
+      whenever(prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId))
+        .thenReturn(Optional.of(prisonerContactRestrictionEntity()))
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
+
+      whenever(prisonerContactRestrictionRepository.saveAndFlush(any()))
+        .thenReturn(request.toEntity())
+
+      val updated = syncService.updatePrisonerContactRestriction(prisonerContactRestrictionId, request)
 
       val contactCaptor = argumentCaptor<PrisonerContactRestrictionEntity>()
 
       verify(prisonerContactRestrictionRepository).saveAndFlush(contactCaptor.capture())
+      verify(prisonerContactRepository).findById(2L)
 
-      // Checks the entity saved
       with(contactCaptor.firstValue) {
-        assertThat(prisonerContactRestrictionId).isEqualTo(1L)
-        assertThat(prisonerContactId).isEqualTo(12345L)
+        assertThat(prisonerContactRestrictionId).isEqualTo(3L)
+        assertThat(prisonerContactId).isEqualTo(2L)
         assertThat(restrictionType).isEqualTo("NONCON")
         assertThat(startDate).isEqualTo(LocalDate.of(2024, 1, 1))
         assertThat(expiryDate).isEqualTo(LocalDate.of(2024, 12, 31))
@@ -155,10 +194,11 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
         assertThat(amendedTime).isAfter(LocalDateTime.now().minusMinutes(5))
       }
 
-      // Checks the model returned
       with(updated) {
-        assertThat(prisonerContactRestrictionId).isEqualTo(1L)
-        assertThat(contactId).isEqualTo(12345L)
+        assertThat(prisonerContactRestrictionId).isEqualTo(3L)
+        assertThat(prisonerContactId).isEqualTo(2L)
+        assertThat(contactId).isEqualTo(1L)
+        assertThat(prisonerNumber).isEqualTo("A1234AA")
         assertThat(restrictionType).isEqualTo("NONCON")
         assertThat(startDate).isEqualTo(LocalDate.of(2024, 1, 1))
         assertThat(expiryDate).isEqualTo(LocalDate.of(2024, 12, 31))
@@ -175,17 +215,23 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
     @Test
     fun `should fail to update a prisoner contact restriction when prisoner contact restriction is not found`() {
       val updateRequest = updatePrisonerContactRestrictionRequest()
-      whenever(prisonerContactRestrictionRepository.findById(1L)).thenReturn(Optional.empty())
+
+      whenever(prisonerContactRestrictionRepository.findById(3L)).thenReturn(Optional.empty())
+
+      whenever(prisonerContactRepository.findById(2L))
+        .thenReturn(Optional.of(prisonerContactEntity()))
+
       assertThrows<EntityNotFoundException> {
-        syncService.updatePrisonerContactRestriction(1L, updateRequest)
+        syncService.updatePrisonerContactRestriction(3L, updateRequest)
       }
-      verify(prisonerContactRestrictionRepository).findById(1L)
+
+      verify(prisonerContactRestrictionRepository).findById(3L)
+      verify(prisonerContactRepository, never()).findById(2L)
     }
   }
 
   private fun updatePrisonerContactRestrictionRequest() =
     SyncUpdatePrisonerContactRestrictionRequest(
-      contactId = 12345L,
       restrictionType = "NONCON",
       startDate = LocalDate.of(2024, 1, 1),
       expiryDate = LocalDate.of(2024, 12, 31),
@@ -199,7 +245,7 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
 
   private fun createPrisonerContactRestrictionRequest() =
     SyncCreatePrisonerContactRestrictionRequest(
-      contactId = 12345L,
+      prisonerContactId = 2L,
       restrictionType = "NONCON",
       startDate = LocalDate.of(2024, 1, 1),
       expiryDate = LocalDate.of(2024, 12, 31),
@@ -211,13 +257,13 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
       createdTime = LocalDateTime.now(),
     )
 
-  private fun contactEntity(
+  private fun prisonerContactRestrictionEntity(
     amendedBy: String? = "editor",
     amendedTime: LocalDateTime? = LocalDateTime.now(),
   ) =
     PrisonerContactRestrictionEntity(
-      prisonerContactRestrictionId = 1L,
-      prisonerContactId = 12345L,
+      prisonerContactRestrictionId = 3L,
+      prisonerContactId = 2L,
       restrictionType = "NONCON",
       startDate = LocalDate.of(2024, 1, 1),
       expiryDate = LocalDate.of(2024, 12, 31),
@@ -232,13 +278,30 @@ class SyncPrisonerContactRestrictionEntityServiceTest {
       it.amendedTime = amendedTime
     }
 
+  private fun prisonerContactEntity() =
+    PrisonerContactEntity(
+      prisonerContactId = 2L,
+      contactId = 1L,
+      prisonerNumber = "A1234AA",
+      contactType = "S",
+      active = true,
+      currentTerm = true,
+      approvedVisitor = true,
+      nextOfKin = true,
+      emergencyContact = true,
+      relationshipType = "MOT",
+      comments = "Restriction due to ongoing investigation",
+      createdBy = "admin",
+      createdTime = LocalDateTime.now(),
+    )
+
   private fun SyncUpdatePrisonerContactRestrictionRequest.toEntity(): PrisonerContactRestrictionEntity {
     val updatedBy = this.updatedBy
     val updatedTime = this.updatedTime
 
     return PrisonerContactRestrictionEntity(
-      prisonerContactRestrictionId = 1L,
-      prisonerContactId = 12345L,
+      prisonerContactRestrictionId = 3L,
+      prisonerContactId = 2L,
       restrictionType = "NONCON",
       startDate = LocalDate.of(2024, 1, 1),
       expiryDate = LocalDate.of(2024, 12, 31),


### PR DESCRIPTION
This PR contains sync-initiated events and tests for:
* Contact addresses
* Contact restrictions
* Prisoner contacts (relationships)
* Prisoner contact restrictions (restrictions on a relationship)
* I found quite a few problems with the code for prisoner contact restrictions - so I will have a sweep through the other side of this, for handling UI requests relating to these.