### PR TITLE
PRC-323: Only allow primary and mail on one address

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/CreateAddressResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/CreateAddressResponse.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
+
+data class CreateAddressResponse(val created: ContactAddressResponse, val otherUpdatedAddressIds: Set<Long>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/UpdateAddressResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/UpdateAddressResponse.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response
+
+data class UpdateAddressResponse(val updated: ContactAddressResponse, val otherUpdatedAddressIds: Set<Long>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/ContactAddressRepository.kt
@@ -12,4 +12,30 @@ interface ContactAddressRepository : JpaRepository<ContactAddressEntity, Long> {
   @Modifying
   @Query("delete from ContactAddressEntity ca where ca.contactId = :contactId")
   fun deleteAllByContactId(contactId: Long): Int
+
+  @Modifying
+  @Query(
+    value = """
+      UPDATE contact_address 
+      SET primary_address = false 
+      WHERE primary_address = true
+      AND contact_id = :contactId 
+      RETURNING contact_address_id
+      """,
+    nativeQuery = true,
+  )
+  fun resetPrimaryAddressFlagForContact(contactId: Long): List<Long>
+
+  @Modifying
+  @Query(
+    value = """
+      UPDATE contact_address 
+      SET mail_flag = false 
+      WHERE mail_flag = true
+      AND contact_id = :contactId 
+      RETURNING contact_address_id
+      """,
+    nativeQuery = true,
+  )
+  fun resetMailAddressFlagForContact(contactId: Long): List<Long>
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
@@ -12,6 +12,8 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.contactAddressResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.createContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers.updateContactAddressRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.CreateAddressResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.UpdateAddressResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactAddressService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEventsService
@@ -31,7 +33,7 @@ class ContactAddressFacadeTest {
     val request = createContactAddressRequest()
     val response = contactAddressResponse(contactAddressId, contactId)
 
-    whenever(addressService.create(any(), any())).thenReturn(response)
+    whenever(addressService.create(any(), any())).thenReturn(CreateAddressResponse(response, emptySet()))
     whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
 
     val result = facade.create(contactId, request)
@@ -69,7 +71,7 @@ class ContactAddressFacadeTest {
     val response = contactAddressResponse(contactAddressId, contactId)
     val request = updateContactAddressRequest()
 
-    whenever(addressService.update(any(), any(), any())).thenReturn(response)
+    whenever(addressService.update(any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
     whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressIntegrationTest.kt
@@ -30,7 +30,7 @@ class DeleteContactAddressIntegrationTest : H2IntegrationTestBase() {
     savedContactAddressId = testAPIClient.createAContactAddress(
       savedContactId,
       CreateContactAddressRequest(
-        primaryAddress = true,
+        primaryAddress = false,
         addressType = "HOME",
         flat = "1A",
         property = "27",


### PR DESCRIPTION
Changed the create and update APIs for contact addresses to remove the primary and mail flags from other addresses if setting them on the subject. Also generates updated events for any other addresses updated.