### PR TITLE
PRC-342: Do not allow null for identity value

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactIdentityEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/ContactIdentityEntity.kt
@@ -20,7 +20,7 @@ data class ContactIdentityEntity(
 
   val identityType: String,
 
-  val identityValue: String? = null,
+  val identityValue: String,
 
   val issuingAuthority: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncCreateContactIdentityRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncCreateContactIdentityRequest.kt
@@ -12,7 +12,7 @@ data class SyncCreateContactIdentityRequest(
   val identityType: String,
 
   @Schema(description = "Identity number or reference", example = "HP9909SM1883")
-  val identityValue: String?,
+  val identityValue: String,
 
   @Schema(description = "Issuing authority ", example = "DVLA")
   val issuingAuthority: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncContactIdentity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncContactIdentity.kt
@@ -15,7 +15,7 @@ data class SyncContactIdentity(
   val identityType: String,
 
   @Schema(description = "Identity ", example = "DL090 0909 909")
-  val identityValue: String?,
+  val identityValue: String,
 
   @Schema(description = "Issuing authority", example = "DVLA")
   val issuingAuthority: String?,

--- a/src/main/resources/migrations/common/V2024.08.02.1__baseline_tables.sql
+++ b/src/main/resources/migrations/common/V2024.08.02.1__baseline_tables.sql
@@ -46,8 +46,8 @@ CREATE TABLE contact_identity
 (
     contact_identity_id bigserial NOT NULL CONSTRAINT contact_identity_id_pk PRIMARY KEY,
     contact_id bigint NOT NULL REFERENCES contact(contact_id),
-    identity_type varchar(12), -- Reference codes - ID_TYPE
-    identity_value varchar(100), -- driving licence number, NI number, passport number
+    identity_type varchar(12) NOT NULL, -- Reference codes - ID_TYPE
+    identity_value varchar(100) NOT NULL, -- driving licence number, NI number, passport number
     issuing_authority varchar(40), -- e.g. UK passport agency, DVLA
     created_by varchar(100) NOT NULL,
     created_time timestamp NOT NULL DEFAULT current_timestamp,


### PR DESCRIPTION
Also made identity value and type non-null in db for extra safety.