### PR TITLE
PRC-349: Re-organise swagger docs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/config/OpenApiConfiguration.kt
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.oas.models.tags.Tag
 import jakarta.annotation.PostConstruct
 import org.openapitools.jackson.nullable.JsonNullableModule
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer
@@ -38,14 +40,67 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
       Info()
         .title("Contacts API")
         .version(version)
-        .description("API for management of contacts")
+        .description("API for management of contacts and their relationships to prisoners including restrictions that apply to the contact or relationship specifically.")
         .contact(
           Contact()
             .name("HMPPS Digital Studio")
             .email("feedback@digital.justice.gov.uk"),
         ),
     )
+    .tags(
+      listOf(
+        Tag().apply {
+          name("Contacts")
+          description("APIs relating to creating and managing a contact")
+        },
+        Tag().apply {
+          name("Prisoner Contact Relationship")
+          description("APIs relating to creating and managing relationships between contacts and prisoners")
+        },
+        Tag().apply {
+          name("Restrictions")
+          description(
+            """
+            APIs relating to creating and managing restrictions. Two kinds of restrictions are supported in this API
+            
+             - Estate wide restrictions, a.k.a global and contact restrictions. These apply to all of a contacts relationships.
+             - Prisoner-contact restrictions. These apply to a relationship between a specific prisoner and contact. 
+             
+            There are also restrictions that can apply to a prisoner and all of their relationships but those are not supported by this API.
+            """.trimIndent(),
+          )
+        },
+        Tag().apply {
+          name("Reference Data")
+          description("APIs relating to reference data used in the service")
+        },
+        Tag().apply {
+          name("Sync & Migrate")
+          description("APIs relating to data sync and migration with NOMIS")
+        },
+      ),
+    )
     .addSecurityItem(SecurityRequirement().addList("bearer-jwt", listOf("read", "write")))
+    .servers(
+      listOf(
+        Server().apply {
+          url("/")
+          description("Default - This environment")
+        },
+        Server().apply {
+          url("https://contacts-api-dev.hmpps.service.justice.gov.uk")
+          description("Development")
+        },
+        Server().apply {
+          url("https://contacts-api-preprod.hmpps.service.justice.gov.uk")
+          description("Pre-production")
+        },
+        Server().apply {
+          url("https://contacts-api.hmpps.service.justice.gov.uk")
+          description("Production")
+        },
+      ),
+    )
 
   @PostConstruct
   fun enableLocalTimePrimitiveType() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CityController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.City
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CityService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "city-reference")
+@Tag(name = "Reference Data")
 @RestController
 @RequestMapping(value = ["city-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Contact Address")
+@Tag(name = "Contacts")
 @RestController
 @RequestMapping(value = ["contact/{contactId}/address"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressPhoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressPhoneController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddre
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Contact Address Phone - address-specific phone numbers")
+@Tag(name = "Contacts")
 @RestController
 @RequestMapping(
   value = ["/contact/{contactId}/address/{contactAddressId}/phone"],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactController.kt
@@ -36,7 +36,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.net.URI
 
-@Tag(name = "Contact")
+@Tag(name = "Contacts")
 @RestController
 @RequestMapping(value = ["contact"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactEmailController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactEmail
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Contact Email")
+@Tag(name = "Contacts")
 @RestController
 @RequestMapping(value = ["contact/{contactId}/email"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactGlobalRestrictionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactGlobalRestrictionController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactRestr
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Contact Global Restrictions", description = "Global restrictions for a contact, a.k.a. estate-wide restrictions or contact restrictions")
+@Tag(name = "Restrictions")
 @RestController
 @RequestMapping(value = ["contact/{contactId}/restriction"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactIdentityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactIdentityController.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactIdent
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Contact Identity")
+@Tag(name = "Contacts")
 @RestController
 @RequestMapping(value = ["contact/{contactId}/identity"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactPhoneController.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactPhone
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Contact Phone")
+@Tag(name = "Contacts")
 @RestController
 @RequestMapping(value = ["contact/{contactId}/phone"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountryController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountryController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Country
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CountryService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "country-reference")
+@Tag(name = "Reference Data")
 @RestController
 @RequestMapping(value = ["country-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountyController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.County
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CountyService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "county-reference")
+@Tag(name = "Reference Data")
 @RestController
 @RequestMapping(value = ["county-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/LanguageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/LanguageController.kt
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,15 +16,11 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.Language
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.LanguageService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
-@Tag(name = "language-reference")
+@Tag(name = "Reference Data")
 @RestController
 @RequestMapping(value = ["language-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
 class LanguageController(private val languageService: LanguageService) {
-
-  companion object {
-    private val logger = LoggerFactory.getLogger(this::class.java)
-  }
 
   @GetMapping("/{id}")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactController.kt
@@ -34,7 +34,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerContactRela
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Prisoner contact")
 @RestController
 @RequestMapping(value = ["prisoner-contact"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
@@ -45,6 +44,7 @@ class PrisonerContactController(
 ) {
 
   @Operation(summary = "Endpoint to get a prisoner contact relationship by relationship id")
+  @Tag(name = "Prisoner Contact Relationship")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -84,6 +84,7 @@ class PrisonerContactController(
     summary = "Update prisoner contact relationship",
     description = "Update the relationship between the contact and a prisoner.",
   )
+  @Tag(name = "Prisoner Contact Relationship")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -121,6 +122,7 @@ class PrisonerContactController(
     summary = "Add a new prisoner contact relationship",
     description = "Creates a new relationship between the contact and a prisoner.",
   )
+  @Tag(name = "Prisoner Contact Relationship")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -163,6 +165,7 @@ class PrisonerContactController(
       If the prisoner and contact have multiple relationships, the prisoner-contact restrictions for the other relationships will not be returned. 
     """,
   )
+  @Tag(name = "Restrictions")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -202,6 +205,7 @@ class PrisonerContactController(
     summary = "Create new prisoner contact restriction",
     description = "Creates a new prisoner contact restriction for the specified prisoner contact relationship",
   )
+  @Tag(name = "Restrictions")
   @ApiResponses(
     value = [
       ApiResponse(
@@ -246,6 +250,7 @@ class PrisonerContactController(
     summary = "Update prisoner contact restriction",
     description = "Updates a prisoner contact restriction for the specified prisoner contact relationship and restriction ids",
   )
+  @Tag(name = "Restrictions")
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerController.kt
@@ -16,44 +16,18 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummaryPage
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerContactService
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.PrisonerService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.PrisonNumberDoc
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Prisoner")
+@Tag(name = "Prisoner Contact Relationship")
 @RestController
 @RequestMapping(value = ["prisoner"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
-class PrisonerController(
-  private val prisonerService: PrisonerService,
-  private val prisonerContactService: PrisonerContactService,
-) {
-
-  @Operation(summary = "Endpoint to get a specific prisoner by prison number")
-  @ApiResponses(
-    value = [
-      ApiResponse(
-        responseCode = "200",
-        description = "List of all contacts for the prisoner",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = PrisonerContactSummary::class),
-          ),
-        ],
-      ),
-    ],
-  )
-  @GetMapping(value = ["/{prisonNumber}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-  @PreAuthorize("hasAnyRole('PRISONER_SEARCH')")
-  fun getPrisoner(
-    @PathVariable("prisonNumber") @PrisonNumberDoc prisonerNumber: String,
-  ): Prisoner? = prisonerService.getPrisoner(prisonerNumber)
+class PrisonerController(private val prisonerContactService: PrisonerContactService) {
 
   @Operation(summary = "Endpoint to fetch all contacts for a specific prisoner by prisoner number and active status")
   @ApiResponses(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ReferenceCodeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ReferenceCodeController.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ReferenceCod
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ReferenceCodeService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Reference Codes Controller")
+@Tag(name = "Reference Data")
 @RestController
 @RequestMapping(value = ["reference-codes"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ReferenceCodeController(private val referenceCodeService: ReferenceCodeService) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigrateContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigrateContactController.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.MigrationSe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Migration")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["migrate/contact"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressPhoneSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressPhoneSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactAddressPhone
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - address-specific phone numbers")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactAddressPhoneSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactAddressSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactAddress
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - contact address")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactAddressSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactEmailSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactEmailSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactEmail
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - contact email")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactEmailSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactIdentitySyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactIdentitySyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactIdentity
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - contact identity")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactIdentitySyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactPhoneSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactPhoneSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactPhone
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - contact phone")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactPhoneSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactRestrictionSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactRestrictionSyncController.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.sync.SyncUpda
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncContactRestriction
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - contact restriction")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ContactRestrictionSyncController(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/ContactSyncController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncCon
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - contact")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactRestrictionSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactRestrictionSyncController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - prisoner contact restriction")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/sync/PrisonerContactSyncController.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.sync.SyncPri
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
-@Tag(name = "Sync endpoints - prisoner contact")
+@Tag(name = "Sync & Migrate")
 @RestController
 @RequestMapping(value = ["/sync"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses


### PR DESCRIPTION
Sort into Contacts, Prisoner Contact Relationships, Restrictions and Reference Data in that order with Sync and Migrate endpoints last.

Also added the server URLs to allow switching for testing and a good way of publicly documenting the URLs.