### PR TITLE
PRC-140: Fix migrations

### DIFF
--- a/run-local.sh
+++ b/run-local.sh
@@ -20,7 +20,7 @@ export API_BASE_URL_HMPPS_AUTH=https://sign-in-dev.hmpps.service.justice.gov.uk/
 export $(cat .env | xargs)  # If you want to set or update the current shell environment e.g. system client and secret.
 
 # Run the application with stdout and local profiles active
-SPRING_PROFILES_ACTIVE=stdout,local,auto-db-clean ./gradlew bootRun
+SPRING_PROFILES_ACTIVE=stdout,local ./gradlew bootRun
 
 # End
 

--- a/src/main/resources/application-auto-db-clean.yaml
+++ b/src/main/resources/application-auto-db-clean.yaml
@@ -1,6 +1,0 @@
-spring:
-  flyway:
-    # This should be removed when we think the DB is stable, and we should be moving onto migrations for changes.
-    # The spring profile "dbclean" is set in the values-dev.yaml file, so it only applies to the DEV db.
-    clean-disabled: false
-    clean-on-validation-error: true

--- a/src/main/resources/migrations/common/R__v_contact_addresses.sql
+++ b/src/main/resources/migrations/common/R__v_contact_addresses.sql
@@ -1,8 +1,10 @@
 --
 -- Creates a view over the contact_address and reference data tables to return a list of all addresses with descriptions
 -- for all codes.
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_contact_addresses
+DROP VIEW IF EXISTS v_contact_addresses;
+CREATE VIEW v_contact_addresses
 AS
 select
     ca.contact_address_id,
@@ -37,6 +39,6 @@ select
   left join city_reference city_ref on city_ref.nomis_code = ca.city_code
   left join county_reference county_ref on county_ref.nomis_code = ca.county_code
   left join country_reference country_ref on country_ref.nomis_code = ca.country_code
-  left join reference_codes rc ON rc.group_code = 'ADDRESS_TYPE' and rc.code = ca.address_type
+  left join reference_codes rc ON rc.group_code = 'ADDRESS_TYPE' and rc.code = ca.address_type;
 
 -- End

--- a/src/main/resources/migrations/common/R__v_contact_identities.sql
+++ b/src/main/resources/migrations/common/R__v_contact_identities.sql
@@ -1,8 +1,10 @@
 --
 -- Creates a view over the contact_identity and reference_codes tables to return a list of all identities with descriptions
 -- for all codes.
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_contact_identities
+DROP VIEW IF EXISTS v_contact_identities;
+CREATE VIEW v_contact_identities
 AS
 select
     ci.contact_identity_id,
@@ -17,6 +19,6 @@ select
     ci.updated_by,
     ci.updated_time
   from contact_identity ci
-  left join reference_codes rc ON rc.group_code = 'ID_TYPE' and rc.code = ci.identity_type
+  left join reference_codes rc ON rc.group_code = 'ID_TYPE' and rc.code = ci.identity_type;
 
 -- End

--- a/src/main/resources/migrations/common/R__v_contact_phone_numbers.sql
+++ b/src/main/resources/migrations/common/R__v_contact_phone_numbers.sql
@@ -1,8 +1,10 @@
 --
 -- Creates a view over the contact_phone and reference_codes tables to return a list of all phone numbers with descriptions
 -- for all codes.
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_contact_phone_numbers
+DROP VIEW IF EXISTS v_contact_phone_numbers;
+CREATE VIEW v_contact_phone_numbers
 AS
 select
     cp.contact_phone_id,
@@ -16,6 +18,6 @@ select
     cp.updated_by,
     cp.updated_time
   from contact_phone cp
-  left join reference_codes rc ON rc.group_code = 'PHONE_TYPE' and rc.code = cp.phone_type
+  left join reference_codes rc ON rc.group_code = 'PHONE_TYPE' and rc.code = cp.phone_type;
 
 -- End

--- a/src/main/resources/migrations/common/R__v_contact_restriction_details.sql
+++ b/src/main/resources/migrations/common/R__v_contact_restriction_details.sql
@@ -1,8 +1,10 @@
 --
 -- Creates a view over the contact_restriction and reference data tables to return a list of contact global restrictions by
 -- contact_id
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_contact_restriction_details
+DROP VIEW IF EXISTS v_contact_restriction_details;
+CREATE VIEW v_contact_restriction_details
 AS
 select
     cr.contact_restriction_id,
@@ -17,6 +19,6 @@ select
     cr.updated_by,
     cr.updated_time
   from contact_restriction cr
-  left join reference_codes rc ON rc.group_code = 'RESTRICTION' and rc.code = cr.restriction_type
+  left join reference_codes rc ON rc.group_code = 'RESTRICTION' and rc.code = cr.restriction_type;
 
 -- End

--- a/src/main/resources/migrations/common/R__v_contacts_with_primary_address.sql
+++ b/src/main/resources/migrations/common/R__v_contacts_with_primary_address.sql
@@ -2,8 +2,10 @@
 -- Creates a view over the contact, contact_address and prisoner_contact tables
 -- to return a list of active or inactive contacts, and their primary addresses,
 -- for a prisoner.
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_contacts_with_primary_address
+DROP VIEW IF EXISTS v_contacts_with_primary_address;
+CREATE VIEW v_contacts_with_primary_address
 AS
 select
     c.contact_id,
@@ -49,6 +51,6 @@ select
   )
   left join city_reference city_ref on city_ref.nomis_code = ca.city_code
   left join county_reference county_ref on county_ref.nomis_code = ca.county_code
-  left join country_reference country_ref on country_ref.nomis_code = ca.country_code
+  left join country_reference country_ref on country_ref.nomis_code = ca.country_code;
 
 -- End

--- a/src/main/resources/migrations/common/R__v_prisoner_contact_restriction_details.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contact_restriction_details.sql
@@ -1,8 +1,10 @@
 --
 -- Creates a view over the prisoner_contact_restriction and reference data tables to return a list of prisoner-contact restrictions by
 -- contact_id
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_prisoner_contact_restriction_details
+DROP VIEW IF EXISTS v_prisoner_contact_restriction_details;
+CREATE VIEW v_prisoner_contact_restriction_details
 AS
 select
     pcr.prisoner_contact_restriction_id,
@@ -17,6 +19,6 @@ select
     pcr.updated_by,
     pcr.updated_time
   from prisoner_contact_restriction pcr
-  left join reference_codes rc ON rc.group_code = 'RESTRICTION' and rc.code = pcr.restriction_type
+  left join reference_codes rc ON rc.group_code = 'RESTRICTION' and rc.code = pcr.restriction_type;
 
 -- End

--- a/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
@@ -2,8 +2,10 @@
 -- Creates a view over the contact, contact_address and prisoner_contact tables
 -- to return a list of active or inactive contacts, and their primary addresses,
 -- for a prisoner, where the current_term is true (latest booking only).
+-- Note: the view is only dropped if the checksum of this migration changes
 --
-CREATE OR REPLACE VIEW v_prisoner_contacts
+DROP VIEW IF EXISTS v_prisoner_contacts;
+CREATE VIEW v_prisoner_contacts
 AS
   select
       c.contact_id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/PostgresIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/PostgresIntegrationTestBase.kt
@@ -8,7 +8,7 @@ import org.springframework.test.context.DynamicPropertySource
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.container.PostgresContainer
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@ActiveProfiles("test", "local-postgres", "auto-db-clean")
+@ActiveProfiles("test", "local-postgres")
 abstract class PostgresIntegrationTestBase : IntegrationTestBase() {
 
   companion object {


### PR DESCRIPTION
Drop views before creating them rather than using CREATE OR REPLACE. This allows re-name and re-order of columns which does not work with CREATE OR REPLACE. These migrations are only re-run if the checksum changes.