### PR TITLE
PRC-365: Add additional event id into contact address phones

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacade.kt
@@ -19,6 +19,7 @@ class ContactAddressPhoneFacade(
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
         identifier = it.contactAddressPhoneId,
+        secondIdentifier = it.contactAddressId,
         contactId = contactId,
       )
     }
@@ -29,6 +30,7 @@ class ContactAddressPhoneFacade(
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
         identifier = it.contactAddressPhoneId,
+        secondIdentifier = it.contactAddressId,
         contactId = contactId,
       )
     }
@@ -39,6 +41,7 @@ class ContactAddressPhoneFacade(
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
         identifier = it.contactAddressPhoneId,
+        secondIdentifier = it.contactAddressId,
         contactId = contactId,
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacade.kt
@@ -307,6 +307,7 @@ class SyncFacade(
   // ================================================================
   fun getContactAddressPhoneById(contactAddressPhoneId: Long) =
     syncContactAddressPhoneService.getContactAddressPhoneById(contactAddressPhoneId)
+
   fun createContactAddressPhone(request: SyncCreateContactAddressPhoneRequest) =
     syncContactAddressPhoneService.createContactAddressPhone(request)
       .also {
@@ -315,6 +316,7 @@ class SyncFacade(
           identifier = it.contactAddressPhoneId,
           contactId = it.contactId,
           source = Source.NOMIS,
+          secondIdentifier = it.contactAddressId,
         )
       }
 
@@ -326,6 +328,7 @@ class SyncFacade(
           identifier = it.contactAddressPhoneId,
           contactId = it.contactId,
           source = Source.NOMIS,
+          secondIdentifier = it.contactAddressId,
         )
       }
 
@@ -337,6 +340,7 @@ class SyncFacade(
           identifier = it.contactAddressPhoneId,
           contactId = it.contactId,
           source = Source.NOMIS,
+          secondIdentifier = it.contactAddressId,
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEvents.kt
@@ -286,7 +286,7 @@ data class OutboundHMPPSDomainEvent(
 data class ContactInfo(val contactId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactAddressInfo(val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactPhoneInfo(val contactPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
-data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
+data class ContactAddressPhoneInfo(val contactAddressPhoneId: Long, val contactAddressId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactEmailInfo(val contactEmailId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactIdentityInfo(val contactIdentityId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)
 data class ContactRestrictionInfo(val contactRestrictionId: Long, override val source: Source = Source.DPS) : AdditionalInformation(source)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/events/OutboundEventsService.kt
@@ -20,6 +20,7 @@ class OutboundEventsService(
     contactId: Long,
     noms: String = "",
     source: Source = Source.DPS,
+    secondIdentifier: Long? = 0,
   ) {
     if (featureSwitches.isEnabled(outboundEvent)) {
       log.info("Sending outbound event $outboundEvent with source $source for identifier $identifier  (contactId $contactId, noms $noms)")
@@ -50,7 +51,7 @@ class OutboundEventsService(
         OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
         OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
         -> {
-          sendSafely(outboundEvent, ContactAddressPhoneInfo(identifier, source), PersonReference(dpsContactId = contactId))
+          sendSafely(outboundEvent, ContactAddressPhoneInfo(identifier, secondIdentifier!!, source), PersonReference(dpsContactId = contactId))
         }
 
         OutboundEvent.CONTACT_EMAIL_CREATED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacadeTest.kt
@@ -34,7 +34,7 @@ class ContactAddressFacadeTest {
     val response = contactAddressResponse(contactAddressId, contactId)
 
     whenever(addressService.create(any(), any())).thenReturn(CreateAddressResponse(response, emptySet()))
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.create(contactId, request)
 
@@ -54,7 +54,7 @@ class ContactAddressFacadeTest {
     val request = createContactAddressRequest()
 
     whenever(addressService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.create(contactId, request)
@@ -63,7 +63,7 @@ class ContactAddressFacadeTest {
     assertThat(exception.message).isEqualTo(expectedException.message)
 
     verify(addressService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -72,7 +72,7 @@ class ContactAddressFacadeTest {
     val request = updateContactAddressRequest()
 
     whenever(addressService.update(any(), any(), any())).thenReturn(UpdateAddressResponse(response, emptySet()))
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(
       contactId = contactId,
@@ -96,7 +96,7 @@ class ContactAddressFacadeTest {
     val request = updateContactAddressRequest()
 
     whenever(addressService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.update(contactId, contactAddressId, request)
@@ -104,7 +104,7 @@ class ContactAddressFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(addressService).update(contactId, contactAddressId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -116,7 +116,7 @@ class ContactAddressFacadeTest {
 
     assertThat(result).isEqualTo(response)
     verify(addressService).get(contactId, contactAddressId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -130,14 +130,14 @@ class ContactAddressFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressService).get(contactId, contactAddressId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     val response = contactAddressResponse(contactAddressId, contactId)
     whenever(addressService.delete(any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactAddressId)
 
@@ -149,7 +149,7 @@ class ContactAddressFacadeTest {
   fun `should not send event if delete throws exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(addressService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactAddressId)
@@ -157,6 +157,6 @@ class ContactAddressFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressService).delete(contactId, contactAddressId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressPhoneFacadeTest.kt
@@ -34,7 +34,7 @@ class ContactAddressPhoneFacadeTest {
     val response = contactAddressPhoneResponse(contactAddressPhoneId, contactAddressId, contactPhoneId, contactId)
 
     whenever(addressPhoneService.create(any(), any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.create(contactId, contactAddressId, request)
 
@@ -43,6 +43,7 @@ class ContactAddressPhoneFacadeTest {
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
       identifier = contactAddressPhoneId,
+      secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
     )
@@ -54,7 +55,7 @@ class ContactAddressPhoneFacadeTest {
     val request = createContactAddressPhoneRequest(contactAddressId)
 
     whenever(addressPhoneService.create(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.create(contactId, contactAddressId, request)
@@ -63,7 +64,7 @@ class ContactAddressPhoneFacadeTest {
     assertThat(exception.message).isEqualTo(expectedException.message)
 
     verify(addressPhoneService).create(contactId, contactAddressId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -72,7 +73,7 @@ class ContactAddressPhoneFacadeTest {
     val request = updateContactAddressPhoneRequest()
 
     whenever(addressPhoneService.update(any(), any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val result = facade.update(
       contactId = contactId,
@@ -85,6 +86,7 @@ class ContactAddressPhoneFacadeTest {
     verify(eventsService).send(
       outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
       identifier = contactAddressPhoneId,
+      secondIdentifier = contactAddressId,
       contactId = contactId,
       source = Source.DPS,
     )
@@ -96,7 +98,7 @@ class ContactAddressPhoneFacadeTest {
     val request = updateContactAddressPhoneRequest()
 
     whenever(addressPhoneService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.update(contactId, contactAddressPhoneId, request)
@@ -104,7 +106,7 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(addressPhoneService).update(contactId, contactAddressPhoneId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -116,7 +118,7 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(result).isEqualTo(response)
     verify(addressPhoneService).get(contactId, contactAddressPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -130,26 +132,32 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressPhoneService).get(contactId, contactAddressPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     val response = contactAddressPhoneResponse(contactAddressPhoneId, contactAddressId, contactPhoneId, contactId)
     whenever(addressPhoneService.delete(any(), any())).thenReturn(response)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactAddressPhoneId)
 
     verify(addressPhoneService).delete(contactId, contactAddressPhoneId)
-    verify(eventsService).send(OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED, contactAddressPhoneId, contactId)
+    verify(eventsService).send(
+      outboundEvent = OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
+      identifier = contactAddressPhoneId,
+      secondIdentifier = contactAddressId,
+      contactId = contactId,
+      source = Source.DPS,
+    )
   }
 
   @Test
   fun `should not send event if delete throws exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(addressPhoneService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactAddressPhoneId)
@@ -157,6 +165,6 @@ class ContactAddressPhoneFacadeTest {
 
     assertThat(exception.message).isEqualTo(expectedException.message)
     verify(addressPhoneService).delete(contactId, contactAddressPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactEmailFacadeTest.kt
@@ -30,7 +30,7 @@ class ContactEmailFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(emailService.create(any(), any())).thenReturn(contactEmailDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = CreateEmailRequest(
       emailAddress = "test@example.com",
       createdBy = "created",
@@ -52,7 +52,7 @@ class ContactEmailFacadeTest {
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = CreateEmailRequest(
       emailAddress = "test@example.com",
       createdBy = "created",
@@ -64,13 +64,13 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(emailService.update(any(), any(), any())).thenReturn(contactEmailDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateEmailRequest(
       emailAddress = "test@example.com",
       updatedBy = "updated",
@@ -92,7 +92,7 @@ class ContactEmailFacadeTest {
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateEmailRequest(
       emailAddress = "test@example.com",
       updatedBy = "updated",
@@ -104,7 +104,7 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).update(contactId, contactEmailId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -115,7 +115,7 @@ class ContactEmailFacadeTest {
 
     assertThat(result).isEqualTo(contactEmailDetails)
     verify(emailService).get(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -128,13 +128,13 @@ class ContactEmailFacadeTest {
 
     assertThat(exception.message).isEqualTo("Contact email with id (99) not found for contact (11)")
     verify(emailService).get(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(emailService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactEmailId)
 
@@ -146,7 +146,7 @@ class ContactEmailFacadeTest {
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(emailService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactEmailId)
@@ -154,6 +154,6 @@ class ContactEmailFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(emailService).delete(contactId, contactEmailId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactGlobalRestrictionsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactGlobalRestrictionsFacadeTest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
@@ -86,7 +86,7 @@ class ContactGlobalRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).createContactGlobalRestriction(contactId, request)
-    verify(outboundEventsService, Mockito.never()).send(any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -148,6 +148,6 @@ class ContactGlobalRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).updateContactGlobalRestriction(contactId, contactRestrictionId, request)
-    verify(outboundEventsService, Mockito.never()).send(any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactIdentityFacadeTest.kt
@@ -30,7 +30,7 @@ class ContactIdentityFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(identityService.create(any(), any())).thenReturn(contactIdentityDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = CreateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
@@ -53,7 +53,7 @@ class ContactIdentityFacadeTest {
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = CreateIdentityRequest(
       identityType = "DL",
       identityValue = "DL123456789",
@@ -66,13 +66,13 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(identityService.update(any(), any(), any())).thenReturn(contactIdentityDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateIdentityRequest(
       identityType = "PASS",
       identityValue = "P978654312",
@@ -95,7 +95,7 @@ class ContactIdentityFacadeTest {
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = UpdateIdentityRequest(
       identityType = "PASS",
       identityValue = "P978654312",
@@ -108,7 +108,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).update(contactId, contactIdentityId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -119,7 +119,7 @@ class ContactIdentityFacadeTest {
 
     assertThat(result).isEqualTo(contactIdentityDetails)
     verify(identityService).get(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -132,13 +132,13 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception.message).isEqualTo("Contact identity with id (99) not found for contact (11)")
     verify(identityService).get(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(identityService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactIdentityId)
 
@@ -155,7 +155,7 @@ class ContactIdentityFacadeTest {
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(identityService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactIdentityId)
@@ -163,6 +163,6 @@ class ContactIdentityFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(identityService).delete(contactId, contactIdentityId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactPhoneFacadeTest.kt
@@ -29,7 +29,7 @@ class ContactPhoneFacadeTest {
   @Test
   fun `should send event if create success`() {
     whenever(phoneService.create(any(), any())).thenReturn(contactPhoneDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = CreatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -52,7 +52,7 @@ class ContactPhoneFacadeTest {
   fun `should not send event if create throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.create(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = CreatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -65,13 +65,13 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).create(contactId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if update success`() {
     whenever(phoneService.update(any(), any(), any())).thenReturn(contactPhoneDetails)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = UpdatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -94,7 +94,7 @@ class ContactPhoneFacadeTest {
   fun `should not send event if update throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.update(any(), any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
     val request = UpdatePhoneRequest(
       phoneType = "MOB",
       phoneNumber = "0777777777",
@@ -107,13 +107,13 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).update(contactId, contactPhoneId, request)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
   fun `should send event if delete success`() {
     whenever(phoneService.delete(any(), any())).then {}
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     facade.delete(contactId, contactPhoneId)
 
@@ -130,7 +130,7 @@ class ContactPhoneFacadeTest {
   fun `should not send event if delete throws exception and propagate the exception`() {
     val expectedException = RuntimeException("Bang!")
     whenever(phoneService.delete(any(), any())).thenThrow(expectedException)
-    whenever(eventsService.send(any(), any(), any(), any(), any())).then {}
+    whenever(eventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
     val exception = assertThrows<RuntimeException> {
       facade.delete(contactId, contactPhoneId)
@@ -138,7 +138,7 @@ class ContactPhoneFacadeTest {
 
     assertThat(exception).isEqualTo(exception)
     verify(phoneService).delete(contactId, contactPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -149,6 +149,6 @@ class ContactPhoneFacadeTest {
 
     assertThat(result).isEqualTo(contactPhoneDetails)
     verify(phoneService).get(contactId, contactPhoneId)
-    verify(eventsService, never()).send(any(), any(), any(), any(), any())
+    verify(eventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerContactRestrictionsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/PrisonerContactRestrictionsFacadeTest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
@@ -90,7 +90,7 @@ class PrisonerContactRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).createPrisonerContactRestriction(prisonerContactId, request)
-    verify(outboundEventsService, Mockito.never()).send(any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -154,6 +154,6 @@ class PrisonerContactRestrictionsFacadeTest {
 
     assertThat(result).isEqualTo(expected)
     verify(restrictionService).updatePrisonerContactRestriction(prisonerContactId, prisonerContactRestrictionId, request)
-    verify(outboundEventsService, Mockito.never()).send(any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/SyncFacadeTest.kt
@@ -84,7 +84,7 @@ class SyncFacadeTest {
       val response = contactResponse(1L)
 
       whenever(syncContactService.createContact(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContact(request)
 
@@ -105,7 +105,7 @@ class SyncFacadeTest {
       val expectedException = RuntimeException("Bang!")
 
       whenever(syncContactService.createContact(any())).thenThrow(expectedException)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val exception = assertThrows<RuntimeException> {
         facade.createContact(request)
@@ -114,7 +114,7 @@ class SyncFacadeTest {
       assertThat(exception.message).isEqualTo(expectedException.message)
 
       verify(syncContactService).createContact(request)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -123,7 +123,7 @@ class SyncFacadeTest {
       val response = contactResponse(3L)
 
       whenever(syncContactService.updateContact(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContact(3L, request)
 
@@ -145,7 +145,7 @@ class SyncFacadeTest {
       val expectedException = RuntimeException("Bang!")
 
       whenever(syncContactService.updateContact(any(), any())).thenThrow(expectedException)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val exception = assertThrows<RuntimeException> {
         facade.updateContact(4L, request)
@@ -154,13 +154,13 @@ class SyncFacadeTest {
       assertThat(exception.message).isEqualTo(expectedException.message)
 
       verify(syncContactService).updateContact(4L, request)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
     }
 
     @Test
     fun `should send domain event on contact delete success`() {
       whenever(syncContactService.deleteContact(any())).then {}
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       facade.deleteContact(1L)
 
@@ -179,7 +179,7 @@ class SyncFacadeTest {
       val expectedException = RuntimeException("Bang!")
 
       whenever(syncContactService.deleteContact(any())).thenThrow(expectedException)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val exception = assertThrows<RuntimeException> {
         facade.deleteContact(1L)
@@ -187,7 +187,7 @@ class SyncFacadeTest {
 
       assertThat(exception.message).isEqualTo(expectedException.message)
       verify(syncContactService).deleteContact(1L)
-      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any())
+      verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
     }
 
     private fun createSyncContactRequest(personId: Long) =
@@ -229,7 +229,7 @@ class SyncFacadeTest {
       val response = contactPhoneResponse(contactId = 1L, contactPhoneId = 1L)
 
       whenever(syncContactPhoneService.createContactPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactPhone(request)
 
@@ -248,7 +248,7 @@ class SyncFacadeTest {
       val response = contactPhoneResponse(contactId = 2L, contactPhoneId = 3L)
 
       whenever(syncContactPhoneService.updateContactPhone(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactPhone(3L, request)
 
@@ -266,7 +266,7 @@ class SyncFacadeTest {
       val response = contactPhoneResponse(contactId = 3L, contactPhoneId = 4L)
 
       whenever(syncContactPhoneService.deleteContactPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactPhone(4L)
 
@@ -319,7 +319,7 @@ class SyncFacadeTest {
       val response = contactEmailResponse(contactId = 1L, contactEmailId = 1L)
 
       whenever(syncContactEmailService.createContactEmail(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactEmail(request)
 
@@ -338,7 +338,7 @@ class SyncFacadeTest {
       val response = contactEmailResponse(contactId = 2L, contactEmailId = 3L)
 
       whenever(syncContactEmailService.updateContactEmail(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactEmail(3L, request)
 
@@ -356,7 +356,7 @@ class SyncFacadeTest {
       val response = contactEmailResponse(contactId = 3L, contactEmailId = 4L)
 
       whenever(syncContactEmailService.deleteContactEmail(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactEmail(4L)
 
@@ -405,7 +405,7 @@ class SyncFacadeTest {
       val response = contactIdentityResponse(contactId = 1L, contactIdentityId = 1L)
 
       whenever(syncContactIdentityService.createContactIdentity(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactIdentity(request)
 
@@ -424,7 +424,7 @@ class SyncFacadeTest {
       val response = contactIdentityResponse(contactId = 2L, contactIdentityId = 3L)
 
       whenever(syncContactIdentityService.updateContactIdentity(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactIdentity(3L, request)
 
@@ -442,7 +442,7 @@ class SyncFacadeTest {
       val response = contactIdentityResponse(contactId = 3L, contactIdentityId = 4L)
 
       whenever(syncContactIdentityService.deleteContactIdentity(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactIdentity(4L)
 
@@ -497,7 +497,7 @@ class SyncFacadeTest {
       val response = contactRestrictionResponse(contactId = 1L, contactRestrictionId = 1L)
 
       whenever(syncContactRestrictionService.createContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactRestriction(request)
 
@@ -516,7 +516,7 @@ class SyncFacadeTest {
       val response = contactRestrictionResponse(contactId = 2L, contactRestrictionId = 3L)
 
       whenever(syncContactRestrictionService.updateContactRestriction(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactRestriction(3L, request)
 
@@ -534,7 +534,7 @@ class SyncFacadeTest {
       val response = contactRestrictionResponse(contactId = 3L, contactRestrictionId = 4L)
 
       whenever(syncContactRestrictionService.deleteContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactRestriction(4L)
 
@@ -592,7 +592,7 @@ class SyncFacadeTest {
       val response = contactAddressResponse(contactId = 1L, contactAddressId = 1L)
 
       whenever(syncContactAddressService.createContactAddress(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactAddress(request)
 
@@ -611,7 +611,7 @@ class SyncFacadeTest {
       val response = contactAddressResponse(contactId = 2L, contactAddressId = 3L)
 
       whenever(syncContactAddressService.updateContactAddress(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactAddress(3L, request)
 
@@ -629,7 +629,7 @@ class SyncFacadeTest {
       val response = contactAddressResponse(contactId = 3L, contactAddressId = 4L)
 
       whenever(syncContactAddressService.deleteContactAddress(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactAddress(4L)
 
@@ -692,7 +692,7 @@ class SyncFacadeTest {
       val response = contactAddressPhoneResponse()
 
       whenever(syncContactAddressPhoneService.createContactAddressPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createContactAddressPhone(request)
 
@@ -702,6 +702,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        secondIdentifier = result.contactAddressId,
       )
     }
 
@@ -711,7 +712,7 @@ class SyncFacadeTest {
       val response = contactAddressPhoneResponse()
 
       whenever(syncContactAddressPhoneService.updateContactAddressPhone(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updateContactAddressPhone(4L, request)
 
@@ -721,6 +722,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        secondIdentifier = result.contactAddressId,
       )
     }
 
@@ -729,7 +731,7 @@ class SyncFacadeTest {
       val response = contactAddressPhoneResponse()
 
       whenever(syncContactAddressPhoneService.deleteContactAddressPhone(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deleteContactAddressPhone(4L)
 
@@ -740,6 +742,7 @@ class SyncFacadeTest {
         identifier = result.contactAddressPhoneId,
         contactId = result.contactId,
         source = Source.NOMIS,
+        secondIdentifier = result.contactAddressId,
       )
     }
 
@@ -785,7 +788,7 @@ class SyncFacadeTest {
       val response = prisonerContactResponse(contactId = 1L, prisonerContactId = 1L)
 
       whenever(syncPrisonerContactService.createPrisonerContact(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createPrisonerContact(request)
 
@@ -805,7 +808,7 @@ class SyncFacadeTest {
       val response = prisonerContactResponse(contactId = 2L, prisonerContactId = 3L)
 
       whenever(syncPrisonerContactService.updatePrisonerContact(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updatePrisonerContact(3L, request)
 
@@ -824,7 +827,7 @@ class SyncFacadeTest {
       val response = prisonerContactResponse(contactId = 3L, prisonerContactId = 4L)
 
       whenever(syncPrisonerContactService.deletePrisonerContact(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deletePrisonerContact(4L)
 
@@ -904,7 +907,7 @@ class SyncFacadeTest {
       )
 
       whenever(syncPrisonerContactRestrictionService.createPrisonerContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.createPrisonerContactRestriction(request)
 
@@ -928,7 +931,7 @@ class SyncFacadeTest {
       )
 
       whenever(syncPrisonerContactRestrictionService.updatePrisonerContactRestriction(any(), any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.updatePrisonerContactRestriction(3L, request)
 
@@ -951,7 +954,7 @@ class SyncFacadeTest {
       )
 
       whenever(syncPrisonerContactRestrictionService.deletePrisonerContactRestriction(any())).thenReturn(response)
-      whenever(outboundEventsService.send(any(), any(), any(), any(), any())).then {}
+      whenever(outboundEventsService.send(any(), any(), any(), any(), any(), any())).then {}
 
       val result = facade.deletePrisonerContactRestriction(3L)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactAddressPhoneIntegrationTest.kt
@@ -186,7 +186,7 @@ class CreateContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_CREATED,
-      additionalInfo = ContactAddressPhoneInfo(created.contactAddressPhoneId, Source.DPS),
+      additionalInfo = ContactAddressPhoneInfo(created.contactAddressPhoneId, created.contactAddressId, Source.DPS),
       personReference = PersonReference(dpsContactId = created.contactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/DeleteContactAddressPhoneIntegrationTest.kt
@@ -140,7 +140,7 @@ class DeleteContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_DELETED,
-      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, Source.DPS),
+      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId, Source.DPS),
       personReference = PersonReference(dpsContactId = savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactAddressPhoneIntegrationTest.kt
@@ -172,7 +172,7 @@ class UpdateContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: $expectedMessage")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId))
   }
 
   @ParameterizedTest
@@ -192,7 +192,7 @@ class UpdateContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure(s): $expectedMessage")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId))
   }
 
   @ParameterizedTest
@@ -221,7 +221,7 @@ class UpdateContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: Phone number invalid, it can only contain numbers, () and whitespace with an optional + at the start")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId))
   }
 
   @Test
@@ -246,7 +246,7 @@ class UpdateContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported phone type (SATELLITE)")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId))
+    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED, ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId))
   }
 
   @ParameterizedTest
@@ -274,7 +274,7 @@ class UpdateContactAddressPhoneIntegrationTest : PostgresIntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.CONTACT_ADDRESS_PHONE_UPDATED,
-      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId),
+      additionalInfo = ContactAddressPhoneInfo(savedAddressPhoneId, savedAddressId),
       personReference = PersonReference(savedContactId),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/patch/ContactFacadeTest.kt
@@ -130,7 +130,7 @@ class ContactFacadeTest {
 
     assertThat(contactFacade.searchContacts(pageable, request)).isEqualTo(result)
 
-    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test
@@ -141,7 +141,7 @@ class ContactFacadeTest {
 
     assertThat(contactFacade.getContact(99L)).isEqualTo(expectedContact)
 
-    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any())
+    verify(outboundEventsService, never()).send(any(), any(), any(), any(), any(), any())
   }
 
   @Test


### PR DESCRIPTION
For contact address phones, and in particular the delete operations, Syscon are unable to retrieve the row by ID after it has been deleted, so need a second ID (the contactAddressId) to work with.