### PR TITLE
PRC-348 : Tech ticket - Add PATCH API for address

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/facade/ContactAddressFacade.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.facade
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.ContactAddressService
@@ -27,6 +28,17 @@ class ContactAddressFacade(
 
   fun update(contactId: Long, contactAddressId: Long, request: UpdateContactAddressRequest): ContactAddressResponse {
     return contactAddressService.update(contactId, contactAddressId, request).also { (updated, otherUpdatedAddressIds) ->
+      outboundEventsService.send(
+        outboundEvent = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+        identifier = updated.contactAddressId,
+        contactId = contactId,
+      )
+      sendOtherUpdatedAddressEvents(otherUpdatedAddressIds, contactId)
+    }.updated
+  }
+
+  fun patch(contactId: Long, contactAddressId: Long, request: PatchContactAddressRequest): ContactAddressResponse {
+    return contactAddressService.patch(contactId, contactAddressId, request).also { (updated, otherUpdatedAddressIds) ->
       outboundEventsService.send(
         outboundEvent = OutboundEvent.CONTACT_ADDRESS_UPDATED,
         identifier = updated.contactAddressId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchContactAddressRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/PatchContactAddressRequest.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+import org.openapitools.jackson.nullable.JsonNullable
+import java.time.LocalDate
+
+@Schema(description = "Request to patch a contact address")
+data class PatchContactAddressRequest(
+  @Schema(
+    description =
+    """
+    The type of address.
+    This is a coded value (from the group code ADDRESS_TYPE in reference data).
+    The known values are HOME, WORK or BUS (business address).
+    """,
+    example = "HOME",
+    nullable = true,
+    maxLength = 12,
+    requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+  )
+  @field:Size(max = 12, message = "addressType must be <= 12 characters")
+  val addressType: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "True if this is the primary address otherwise false", example = "true", nullable = false, type = "boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val primaryAddress: JsonNullable<Boolean> = JsonNullable.undefined(),
+
+  @Schema(description = "Flat number or name", example = "Flat 2B", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val flat: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "Building or house number or name", example = "Mansion House", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val property: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "Street or road name", example = "Acacia Avenue", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val street: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "Area", example = "Morton Heights", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val area: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "City code - from NOMIS reference data", example = "BIRM", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 12, message = "cityCode must be <= 12 characters")
+  val cityCode: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "County code - from NOMIS reference data", example = "WMIDS", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 12, message = "countyCode must be <= 12 characters")
+  val countyCode: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "Postcode", example = "S13 4FH", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val postcode: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "Country code - from NOMIS reference data", example = "UK", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @field:Size(max = 12, message = "countryCode must be <= 12 characters")
+  val countryCode: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "Whether the address has been verified by postcode lookup", example = "false", nullable = false, type = "boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val verified: JsonNullable<Boolean> = JsonNullable.undefined(),
+
+  @Schema(description = "Whether the address can be used for mailing", example = "false", nullable = false, type = "boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val mailFlag: JsonNullable<Boolean> = JsonNullable.undefined(),
+
+  @Schema(description = "The start date when this address can be considered active from", example = "2023-01-12", type = "string", nullable = true, format = "yyyy-MM-dd", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val startDate: JsonNullable<LocalDate?> = JsonNullable.undefined(),
+
+  @Schema(description = "The end date when this address can be considered active until", example = "2023-01-12", type = "string", nullable = true, format = "yyyy-MM-dd", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val endDate: JsonNullable<LocalDate?> = JsonNullable.undefined(),
+
+  @Schema(description = "Flag to indicate this address should be considered as no fixed address", example = "false", nullable = false, type = "boolean", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val noFixedAddress: JsonNullable<Boolean> = JsonNullable.undefined(),
+
+  @Schema(description = "Any additional information or comments about the address", example = "Some additional information", nullable = true, type = "string", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  val comments: JsonNullable<String?> = JsonNullable.undefined(),
+
+  @Schema(description = "The id of the user who updated the address", example = "JD000001", nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
+  @field:Size(max = 100, message = "updatedBy must be <= 100 characters")
+  val updatedBy: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactAddressController.kt
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.facade.ContactAddressFacade
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
@@ -110,6 +112,44 @@ class ContactAddressController(private val contactAddressFacade: ContactAddressF
     @Valid @RequestBody
     request: UpdateContactAddressRequest,
   ) = contactAddressFacade.update(contactId, contactAddressId, request)
+
+  @PatchMapping("/{contactAddressId}", consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(summary = "Patch a contact address individual fields as a patch", description = "Patches an existing contact address by its ID")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Patched the contact address successfully",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ContactAddressResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The request has invalid or missing fields",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Could not find the the contact or address by ID",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_CONTACTS_ADMIN', 'ROLE_CONTACTS__RW')")
+  fun patchContactAddress(
+    @PathVariable("contactId")
+    @Parameter(name = "contactId", description = "The contact ID", example = "123456")
+    contactId: Long,
+    @PathVariable("contactAddressId")
+    @Parameter(name = "contactAddressId", description = "The contact address ID", example = "1233")
+    contactAddressId: Long,
+    @Valid @RequestBody
+    request: PatchContactAddressRequest,
+  ) = contactAddressFacade.patch(contactId, contactAddressId, request)
 
   @GetMapping("/{contactAddressId}")
   @Operation(summary = "Get a contact address", description = "Get a contact address by its ID")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.helpers
 
+import org.openapitools.jackson.nullable.JsonNullable
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressDetailsEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEmailEntity
@@ -9,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactRestrictionDe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.PrisonerContactRestrictionDetailsEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressDetails
@@ -459,6 +461,17 @@ fun updateContactAddressRequest(
   area = area,
   postcode = postcode,
   updatedBy = updatedBy,
+)
+
+fun patchContactAddressRequest() = PatchContactAddressRequest(
+  primaryAddress = JsonNullable.of(true),
+  addressType = JsonNullable.of("HOME"),
+  flat = JsonNullable.of("1B"),
+  property = JsonNullable.of("35"),
+  street = JsonNullable.of("Acacia Avenue"),
+  area = JsonNullable.of("Bulls Nose"),
+  postcode = JsonNullable.of("EC1 2NJ"),
+  updatedBy = "AMEND_USER",
 )
 
 fun contactAddressResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateEmailRe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateIdentityRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreatePrisonerContactRestrictionRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressPhoneRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactRestrictionRequest
@@ -481,6 +482,21 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
 
   fun updateAContactAddress(contactId: Long, contactAddressId: Long, request: UpdateContactAddressRequest, role: String = "ROLE_CONTACTS_ADMIN"): ContactAddressResponse {
     return webTestClient.put()
+      .uri("/contact/$contactId/address/$contactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(authorised(role))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ContactAddressResponse::class.java)
+      .returnResult().responseBody!!
+  }
+
+  fun patchAContactAddress(contactId: Long, contactAddressId: Long, request: PatchContactAddressRequest, role: String = "ROLE_CONTACTS_ADMIN"): ContactAddressResponse {
+    return webTestClient.patch()
       .uri("/contact/$contactId/address/$contactAddressId")
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactAddressIntegrationTest.kt
@@ -1,0 +1,603 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.openapitools.jackson.nullable.JsonNullable
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactAddressRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.ContactAddressInfo
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.PersonReference
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.events.Source
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+import java.time.LocalDate
+
+class PatchContactAddressIntegrationTest : PostgresIntegrationTestBase() {
+  private var savedContactId = 0L
+  private var savedContactAddressId = 0L
+
+  @BeforeEach
+  fun initialiseData() {
+    savedContactId = testAPIClient.createAContact(
+      CreateContactRequest(
+        lastName = "address",
+        firstName = "has",
+        createdBy = "created",
+      ),
+
+    ).id
+
+    savedContactAddressId = testAPIClient.createAContactAddress(
+      savedContactId,
+      CreateContactAddressRequest(
+        primaryAddress = false,
+        mailFlag = false,
+        addressType = "HOME",
+        flat = "1A",
+        property = "27",
+        street = "Acacia Avenue",
+        area = "Hoggs Bottom",
+        postcode = "HB10 2NB",
+        createdBy = "created",
+      ),
+
+    ).contactAddressId
+  }
+
+  @Test
+  fun `should return unauthorized if no token`() {
+    webTestClient.patch()
+      .uri("/contact/$savedContactId/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(aMinimalPatchAddressRequest())
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden if no role`() {
+    webTestClient.patch()
+      .uri("/contact/$savedContactId/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(aMinimalPatchAddressRequest())
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should return forbidden if wrong role`() {
+    webTestClient.patch()
+      .uri("/contact/$savedContactId/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(aMinimalPatchAddressRequest())
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "updatedBy must not be null;{\"updatedBy\": null}",
+      "updatedBy must not be null;{}",
+    ],
+    delimiter = ';',
+  )
+  fun `should return bad request if required fields are null`(expectedMessage: String, json: String) {
+    val errors = webTestClient.patch()
+      .uri("/contact/$savedContactId/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(json)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Validation failure: $expectedMessage")
+
+    stubEvents.assertHasNoEvents(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource("allFieldConstraintViolations")
+  fun `should enforce field constraints`(expectedMessage: String, request: PatchContactAddressRequest) {
+    val errors = webTestClient.patch()
+      .uri("/contact/$savedContactId/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Validation failure(s): $expectedMessage")
+
+    stubEvents.assertHasNoEvents(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource("referenceTypeNotFound")
+  fun `should enforce reference type value validation`(expectedMessage: String, request: PatchContactAddressRequest) {
+    val errors = webTestClient.patch()
+      .uri("/contact/$savedContactId/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Entity not found : $expectedMessage")
+
+    stubEvents.assertHasNoEvents(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+    )
+  }
+
+  @Test
+  fun `should not update the address if the contact is not found`() {
+    val request = aMinimalPatchAddressRequest()
+
+    val errors = webTestClient.patch()
+      .uri("/contact/-321/address/$savedContactAddressId")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Entity not found : Contact (-321) not found")
+
+    stubEvents.assertHasNoEvents(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+    )
+  }
+
+  @Test
+  fun `should not update the address if the id is not found`() {
+    val request = aMinimalPatchAddressRequest()
+
+    val errors = webTestClient.patch()
+      .uri("/contact/$savedContactId/address/-99")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(errors.userMessage).isEqualTo("Entity not found : Contact address (-99) not found")
+
+    stubEvents.assertHasNoEvents(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(-99, Source.DPS),
+    )
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__RW"])
+  fun `should update the address`(role: String) {
+    val request = PatchContactAddressRequest(
+      addressType = JsonNullable.of("HOME"),
+      primaryAddress = JsonNullable.of(true),
+      flat = JsonNullable.of("13"),
+      property = JsonNullable.of("28"),
+      street = JsonNullable.of("Acacia Avenue"),
+      area = JsonNullable.of("Hoggs Bottom"),
+      cityCode = JsonNullable.of("11498"),
+      countyCode = JsonNullable.of("SOMERSET"),
+      postcode = JsonNullable.of("HB10 1DJ"),
+      countryCode = JsonNullable.of("ENG"),
+      verified = JsonNullable.of(false),
+      mailFlag = JsonNullable.of(false),
+      startDate = JsonNullable.of(LocalDate.of(2000, 12, 25)),
+      endDate = JsonNullable.of(LocalDate.of(2001, 12, 25)),
+      noFixedAddress = JsonNullable.of(false),
+      comments = JsonNullable.of("No comments"),
+      updatedBy = "updated",
+    )
+
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+      role,
+    )
+
+    with(updated) {
+      assertThat(addressType).isEqualTo("HOME")
+      assertThat(primaryAddress).isTrue()
+      assertThat(flat).isEqualTo("13")
+      assertThat(property).isEqualTo("28")
+      assertThat(street).isEqualTo("Acacia Avenue")
+      assertThat(area).isEqualTo("Hoggs Bottom")
+      assertThat(cityCode).isEqualTo("11498")
+      assertThat(countyCode).isEqualTo("SOMERSET")
+      assertThat(postcode).isEqualTo("HB10 1DJ")
+      assertThat(countryCode).isEqualTo("ENG")
+      assertThat(verified).isFalse()
+      assertThat(mailFlag).isFalse()
+      assertThat(startDate).isEqualTo(LocalDate.of(2000, 12, 25))
+      assertThat(endDate).isEqualTo(LocalDate.of(2001, 12, 25))
+      assertThat(noFixedAddress).isFalse()
+      assertThat(comments).isEqualTo("No comments")
+      assertThat(createdBy).isEqualTo("created")
+      assertThat(createdTime).isNotNull()
+      assertThat(updatedBy).isEqualTo("updated")
+      assertThat(updatedTime).isNotNull()
+    }
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = savedContactId),
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource("setNullOnGivenField")
+  fun `should allow null on nullable field`(expectedField: String, request: PatchContactAddressRequest) {
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+    val fieldValue = updated::class.members
+      .firstOrNull { it.name == expectedField }
+      ?.call(updated)
+
+    assertThat(fieldValue).isNull()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = savedContactId),
+    )
+  }
+
+  @Test
+  fun `should remove primary flag from current primary addresses if setting primary`() {
+    val requestToCreatePrimary = aMinimalCreateAddressRequest().copy(primaryAddress = true)
+    val primary = testAPIClient.createAContactAddress(savedContactId, requestToCreatePrimary)
+
+    val request = aMinimalPatchAddressRequest().copy(primaryAddress = JsonNullable.of(true))
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+
+    val addresses = testAPIClient.getContact(savedContactId).addresses
+    assertThat(addresses.find { it.contactAddressId == primary.contactAddressId }!!.primaryAddress).isFalse()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.primaryAddress).isTrue()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+  }
+
+  @Test
+  fun `should not remove primary flag from current primary addresses if not setting primary`() {
+    val requestToCreatePrimary = aMinimalCreateAddressRequest().copy(primaryAddress = true)
+    val primary = testAPIClient.createAContactAddress(savedContactId, requestToCreatePrimary)
+
+    val request = aMinimalPatchAddressRequest().copy(primaryAddress = JsonNullable.of(false))
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+
+    val addresses = testAPIClient.getContact(savedContactId).addresses
+    assertThat(addresses.find { it.contactAddressId == primary.contactAddressId }!!.primaryAddress).isTrue()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.primaryAddress).isFalse()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+  }
+
+  @Test
+  fun `should remove mail flag from current mail addresses if setting mail`() {
+    val requestToCreateMail = aMinimalCreateAddressRequest().copy(mailFlag = true)
+    val mail = testAPIClient.createAContactAddress(savedContactId, requestToCreateMail)
+
+    val request = aMinimalPatchAddressRequest().copy(mailFlag = JsonNullable.of(true))
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+
+    val addresses = testAPIClient.getContact(savedContactId).addresses
+    assertThat(addresses.find { it.contactAddressId == mail.contactAddressId }!!.mailFlag).isFalse()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.mailFlag).isTrue()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+  }
+
+  @Test
+  fun `should not remove mail flag from current mail addresses if not setting mail`() {
+    val requestToCreateMail = aMinimalCreateAddressRequest().copy(mailFlag = true, primaryAddress = false)
+    val mail = testAPIClient.createAContactAddress(savedContactId, requestToCreateMail)
+
+    val request = aMinimalPatchAddressRequest().copy(mailFlag = JsonNullable.of(false))
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+
+    val addresses = testAPIClient.getContact(savedContactId).addresses
+    assertThat(addresses.find { it.contactAddressId == mail.contactAddressId }!!.mailFlag).isTrue()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.mailFlag).isFalse()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+  }
+
+  @Test
+  fun `should remove primary and mail flag from current primary and mail addresses if setting primary and mail`() {
+    val requestToCreatePrimary = aMinimalCreateAddressRequest().copy(primaryAddress = true, mailFlag = false)
+    val primary = testAPIClient.createAContactAddress(savedContactId, requestToCreatePrimary)
+
+    val requestToCreateMail = aMinimalCreateAddressRequest().copy(primaryAddress = false, mailFlag = true)
+    val mail = testAPIClient.createAContactAddress(savedContactId, requestToCreateMail)
+
+    val requestToCreateOtherAddress = aMinimalCreateAddressRequest().copy(primaryAddress = false, mailFlag = false)
+    val other = testAPIClient.createAContactAddress(savedContactId, requestToCreateOtherAddress)
+
+    val request = aMinimalPatchAddressRequest().copy(
+      primaryAddress = JsonNullable.of(true),
+      mailFlag = JsonNullable.of(true),
+    )
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+
+    val addresses = testAPIClient.getContact(savedContactId).addresses
+    assertThat(addresses.find { it.contactAddressId == primary.contactAddressId }!!.primaryAddress).isFalse()
+    assertThat(addresses.find { it.contactAddressId == mail.contactAddressId }!!.mailFlag).isFalse()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.primaryAddress).isTrue()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.mailFlag).isTrue()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(primary.contactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(mail.contactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+    stubEvents.assertHasNoEvents(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(other.contactAddressId, Source.DPS),
+    )
+  }
+
+  @Test
+  fun `should remove primary and mail flag from current combined primary mail address if setting primary and mail`() {
+    val requestToCreatePrimaryAndMail = aMinimalCreateAddressRequest().copy(primaryAddress = true, mailFlag = true)
+    val primaryAndMail = testAPIClient.createAContactAddress(
+      savedContactId,
+      requestToCreatePrimaryAndMail,
+    )
+
+    val request = aMinimalPatchAddressRequest().copy(
+      primaryAddress = JsonNullable.of(true),
+      mailFlag = JsonNullable.of(true),
+    )
+    val updated = testAPIClient.patchAContactAddress(
+      savedContactId,
+      savedContactAddressId,
+      request,
+    )
+
+    val addresses = testAPIClient.getContact(savedContactId).addresses
+    assertThat(addresses.find { it.contactAddressId == primaryAndMail.contactAddressId }!!.primaryAddress).isFalse()
+    assertThat(addresses.find { it.contactAddressId == primaryAndMail.contactAddressId }!!.mailFlag).isFalse()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.primaryAddress).isTrue()
+    assertThat(addresses.find { it.contactAddressId == updated.contactAddressId }!!.mailFlag).isTrue()
+
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(savedContactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+    stubEvents.assertHasEvent(
+      event = OutboundEvent.CONTACT_ADDRESS_UPDATED,
+      additionalInfo = ContactAddressInfo(primaryAndMail.contactAddressId, Source.DPS),
+      personReference = PersonReference(dpsContactId = updated.contactId),
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun allFieldConstraintViolations(): List<Arguments> {
+      return listOf(
+        Arguments.of(
+          "addressType must be <= 12 characters",
+          aMinimalPatchAddressRequest().copy(addressType = JsonNullable.of("".padStart(13))),
+        ),
+        Arguments.of(
+          "cityCode must be <= 12 characters",
+          aMinimalPatchAddressRequest().copy(cityCode = JsonNullable.of("".padStart(13))),
+        ),
+        Arguments.of(
+          "countyCode must be <= 12 characters",
+          aMinimalPatchAddressRequest().copy(countyCode = JsonNullable.of("".padStart(13))),
+        ),
+        Arguments.of(
+          "countryCode must be <= 12 characters",
+          aMinimalPatchAddressRequest().copy(countryCode = JsonNullable.of("".padStart(13))),
+        ),
+        Arguments.of(
+          "updatedBy must be <= 100 characters",
+          aMinimalPatchAddressRequest().copy(updatedBy = "".padStart(101)),
+        ),
+      )
+    }
+
+    @JvmStatic
+    fun referenceTypeNotFound(): List<Arguments> {
+      return listOf(
+        Arguments.of(
+          "No reference data found for groupCode: CITY and code: INVALID",
+          aMinimalPatchAddressRequest().copy(cityCode = JsonNullable.of("INVALID")),
+        ),
+        Arguments.of(
+          "No reference data found for groupCode: COUNTY and code: INVALID",
+          aMinimalPatchAddressRequest().copy(countyCode = JsonNullable.of("INVALID")),
+        ),
+        Arguments.of(
+          "No reference data found for groupCode: COUNTRY and code: INVALID",
+          aMinimalPatchAddressRequest().copy(countryCode = JsonNullable.of("INVALID")),
+        ),
+      )
+    }
+
+    @JvmStatic
+    fun setNullOnGivenField(): List<Arguments> {
+      return listOf(
+
+        Arguments.of(
+          "addressType",
+          aMinimalPatchAddressRequest().copy(addressType = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "flat",
+          aMinimalPatchAddressRequest().copy(flat = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "property",
+          aMinimalPatchAddressRequest().copy(property = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "street",
+          aMinimalPatchAddressRequest().copy(street = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "area",
+          aMinimalPatchAddressRequest().copy(area = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "cityCode",
+          aMinimalPatchAddressRequest().copy(cityCode = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "countyCode",
+          aMinimalPatchAddressRequest().copy(countyCode = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "countryCode",
+          aMinimalPatchAddressRequest().copy(countryCode = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "postcode",
+          aMinimalPatchAddressRequest().copy(postcode = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "startDate",
+          aMinimalPatchAddressRequest().copy(startDate = JsonNullable.of(null)),
+        ),
+        Arguments.of(
+          "endDate",
+          aMinimalPatchAddressRequest().copy(endDate = JsonNullable.of(null)),
+        ),
+
+        Arguments.of(
+          "comments",
+          aMinimalPatchAddressRequest().copy(comments = JsonNullable.of(null)),
+        ),
+      )
+    }
+
+    private fun aMinimalPatchAddressRequest() = PatchContactAddressRequest(
+      updatedBy = "updated",
+    )
+
+    private fun aMinimalCreateAddressRequest() = CreateContactAddressRequest(
+      addressType = "HOME",
+      primaryAddress = false,
+      mailFlag = false,
+      property = "27",
+      street = "Hello Road",
+      createdBy = "created",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactAddressServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactAddressServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.service
 
 import jakarta.persistence.EntityNotFoundException
+import jakarta.validation.ValidationException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -15,15 +16,19 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.openapitools.jackson.nullable.JsonNullable
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactAddressEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ContactEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.ReferenceCodeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.CreateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.EstimatedIsOverEighteen
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.PatchContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateContactAddressRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactAddressRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.ReferenceCodeRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -50,7 +55,6 @@ class ContactAddressServiceTest {
     val contactAddress = contactAddressService.get(contactId, contactAddressId)
 
     with(contactAddress) {
-      assertThat(addressType).isEqualTo("HOME")
       assertThat(primaryAddress).isTrue()
       assertThat(flat).isEqualTo("1B")
       assertThat(property).isEqualTo("Mason House")
@@ -468,6 +472,472 @@ class ContactAddressServiceTest {
       verify(contactAddressRepository, never()).saveAndFlush(any())
     }
   }
+
+  @Nested
+  inner class PatchContactAddress {
+
+    val request = patchContactAddressRequest()
+
+    @BeforeEach
+    fun setUp() {
+      whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(contactEntity()))
+
+      whenever(contactAddressRepository.findById(contactAddressId))
+        .thenReturn(Optional.of(request.toEntity(contactId, contactAddressId)))
+
+      whenever(contactAddressRepository.saveAndFlush(any()))
+        .thenReturn(request.toEntity(contactId, contactAddressId))
+    }
+
+    @Test
+    fun `should throw EntityNotFoundException when contact does not exist`() {
+      val request = PatchContactAddressRequest(
+        updatedBy = "system",
+      )
+
+      whenever(contactRepository.findById(contactId)).thenReturn(Optional.empty())
+
+      assertThrows<EntityNotFoundException> {
+        contactAddressService.patch(contactId, contactAddressId, request)
+      }
+    }
+
+    @Test
+    fun `should throw EntityNotFoundException when contact address does not exist`() {
+      val request = PatchContactAddressRequest(
+        updatedBy = "system",
+      )
+
+      whenever(contactAddressRepository.findById(contactAddressId)).thenReturn(Optional.empty())
+
+      assertThrows<EntityNotFoundException> {
+        contactAddressService.patch(contactId, contactAddressId, request)
+      }
+    }
+
+    @Test
+    fun `should throw EntityNotFoundException when contact address city code does not exist`() {
+      val groupCode = "CITY"
+      val cityCode = "BHAM"
+      val request = PatchContactAddressRequest(
+        cityCode = JsonNullable.of(cityCode),
+        updatedBy = "system",
+      )
+
+      whenever(referenceCodeRepository.findByGroupCodeAndCode(groupCode, cityCode)).thenReturn(null)
+
+      val exception = assertThrows<EntityNotFoundException> {
+        contactAddressService.patch(contactId, contactAddressId, request)
+      }
+
+      exception.message isEqualTo "No reference data found for groupCode: $groupCode and code: $cityCode"
+    }
+
+    @Test
+    fun `should throw EntityNotFoundException when contact address county code does not exist`() {
+      val groupCode = "COUNTY"
+      val countyCode = "WM"
+      val request = PatchContactAddressRequest(
+        countyCode = JsonNullable.of(countyCode),
+        updatedBy = "system",
+      )
+
+      whenever(referenceCodeRepository.findByGroupCodeAndCode(groupCode, countyCode)).thenReturn(null)
+
+      val exception = assertThrows<EntityNotFoundException> {
+        contactAddressService.patch(contactId, contactAddressId, request)
+      }
+
+      exception.message isEqualTo "No reference data found for groupCode: $groupCode and code: $countyCode"
+    }
+
+    @Test
+    fun `should throw EntityNotFoundException when contact address country code does not exist`() {
+      val groupCode = "COUNTRY"
+      val countryCode = "WM"
+      val request = PatchContactAddressRequest(
+        countryCode = JsonNullable.of(countryCode),
+        updatedBy = "system",
+      )
+
+      whenever(referenceCodeRepository.findByGroupCodeAndCode(groupCode, countryCode)).thenReturn(null)
+
+      val exception = assertThrows<EntityNotFoundException> {
+        contactAddressService.patch(contactId, contactAddressId, request)
+      }
+
+      exception.message isEqualTo "No reference data found for groupCode: $groupCode and code: $countryCode"
+    }
+
+    @Test
+    fun `should patch primary address when primary address flag is set and not primary address already`() {
+      val request = PatchContactAddressRequest(
+        primaryAddress = JsonNullable.of(true),
+        updatedBy = "system",
+      )
+
+      whenever(contactAddressRepository.resetPrimaryAddressFlagForContact(contactId)).thenReturn(listOf(987564321L, 123456789L))
+
+      val (_, otherUpdatedIds) = contactAddressService.patch(contactId, contactAddressId, request)
+
+      assertThat(otherUpdatedIds).isEqualTo(setOf(987564321L, 123456789L))
+    }
+
+    @Test
+    fun `should patch mail address flag when mail flag is set and not mail address already`() {
+      val request = PatchContactAddressRequest(
+        mailFlag = JsonNullable.of(true),
+        updatedBy = "system",
+      )
+
+      whenever(contactAddressRepository.resetMailAddressFlagForContact(contactId)).thenReturn(listOf(987564321L, 123456789L))
+
+      val (_, otherUpdatedIds) = contactAddressService.patch(contactId, contactAddressId, request)
+
+      assertThat(otherUpdatedIds).isEqualTo(setOf(987564321L, 123456789L))
+    }
+
+    @Test
+    fun `should throw ValidationException when contact address not linked to this address`() {
+      val request = PatchContactAddressRequest(
+        updatedBy = "system",
+      )
+
+      whenever(contactAddressRepository.findById(contactAddressId)).thenReturn(
+        Optional.of(
+          contactAddressEntity(
+            contactId = 5L,
+            contactAddressId = contactAddressId,
+          ),
+        ),
+      )
+
+      val exception = assertThrows<ValidationException> {
+        contactAddressService.patch(contactId, contactAddressId, request)
+      }
+
+      exception.message isEqualTo "Contact ID $contactId is not linked to the address $contactAddressId"
+    }
+
+    @Test
+    fun `should patch when only the updated by field is provided`() {
+      val request = PatchContactAddressRequest(
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.updatedBy).isEqualTo(request.updatedBy)
+    }
+
+    @Test
+    fun `should patch when only the primaryAddress field is provided and is set to false when existing address is primary address`() {
+      val request = PatchContactAddressRequest(
+        primaryAddress = JsonNullable.of(false),
+        updatedBy = "Modifier",
+      )
+
+      whenever(contactAddressRepository.findById(contactAddressId)).thenReturn(Optional.of(contactAddressEntity(primaryAddress = true)))
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.primaryAddress).isEqualTo(request.primaryAddress.get())
+    }
+
+    @Test
+    fun `should patch when only the address type field is provided`() {
+      val request = PatchContactAddressRequest(
+        addressType = JsonNullable.of("HOME"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.addressType).isEqualTo(request.addressType.get())
+    }
+
+    @Test
+    fun `should patch when only the flat field is provided`() {
+      val request = PatchContactAddressRequest(
+        flat = JsonNullable.of("1 A"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.flat).isEqualTo(request.flat.get())
+    }
+
+    @Test
+    fun `should patch when only the property field is provided`() {
+      val request = PatchContactAddressRequest(
+        property = JsonNullable.of("No 20"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.property).isEqualTo(request.property.get())
+    }
+
+    @Test
+    fun `should patch when only the street field is provided`() {
+      val request = PatchContactAddressRequest(
+        street = JsonNullable.of("Bluebell Cress"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.street).isEqualTo(request.street.get())
+    }
+
+    @Test
+    fun `should patch when only the area field is provided`() {
+      val request = PatchContactAddressRequest(
+        area = JsonNullable.of("West midlands"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.area).isEqualTo(request.area.get())
+    }
+
+    @Test
+    fun `should patch when only the cityCode field is provided`() {
+      val request = PatchContactAddressRequest(
+        cityCode = JsonNullable.of("Birmingham"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.cityCode).isEqualTo(request.cityCode.get())
+    }
+
+    @Test
+    fun `should patch when only the countyCode field is provided`() {
+      val request = PatchContactAddressRequest(
+        countyCode = JsonNullable.of("WM"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.countyCode).isEqualTo(request.countyCode.get())
+    }
+
+    @Test
+    fun `should patch when only the countryCode field is provided`() {
+      val request = PatchContactAddressRequest(
+        countryCode = JsonNullable.of("UK"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.countryCode).isEqualTo(request.countryCode.get())
+    }
+
+    @Test
+    fun `should patch when only the postcode field is provided`() {
+      val request = PatchContactAddressRequest(
+        postcode = JsonNullable.of("B42 2FS"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.postCode).isEqualTo(request.postcode.get())
+    }
+
+    @Test
+    fun `should patch when only the verified field is provided`() {
+      val request = PatchContactAddressRequest(
+        verified = JsonNullable.of(true),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.verified).isEqualTo(request.verified.get())
+    }
+
+    @Test
+    fun `should patch when only the mailFlag field is provided`() {
+      val request = PatchContactAddressRequest(
+        mailFlag = JsonNullable.of(true),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.mailFlag).isEqualTo(request.mailFlag.get())
+    }
+
+    @Test
+    fun `should patch when only the startDate field is provided`() {
+      val request = PatchContactAddressRequest(
+        startDate = JsonNullable.of(LocalDate.of(2020, 4, 5)),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.startDate).isEqualTo(request.startDate.get())
+    }
+
+    @Test
+    fun `should patch when only the endDate field is provided`() {
+      val request = PatchContactAddressRequest(
+        endDate = JsonNullable.of(LocalDate.of(2020, 4, 5)),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.endDate).isEqualTo(request.endDate.get())
+    }
+
+    @Test
+    fun `should patch when only the noFixedAddress field is provided`() {
+      val request = PatchContactAddressRequest(
+        noFixedAddress = JsonNullable.of(true),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.noFixedAddress).isEqualTo(request.noFixedAddress.get())
+    }
+
+    @Test
+    fun `should patch when only the comments field is provided`() {
+      val request = PatchContactAddressRequest(
+        comments = JsonNullable.of("comments"),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.comments).isEqualTo(request.comments.get())
+    }
+
+    @Test
+    fun `should patch updatedTime when only the updatedBy field is provided`() {
+      val request = PatchContactAddressRequest(
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.updatedTime).isInThePast()
+    }
+
+    @Test
+    fun `should patch verifiedBy when only the verified field is provided`() {
+      val request = PatchContactAddressRequest(
+        verified = JsonNullable.of(true),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.verifiedBy).isEqualTo(request.updatedBy)
+    }
+
+    @Test
+    fun `should patch verifiedTime when only the verified field is provided`() {
+      val request = PatchContactAddressRequest(
+        verified = JsonNullable.of(true),
+        updatedBy = "Modifier",
+      )
+
+      contactAddressService.patch(contactId, contactAddressId, request)
+
+      val contactCaptor = argumentCaptor<ContactAddressEntity>()
+
+      verify(contactAddressRepository).saveAndFlush(contactCaptor.capture())
+      val updatingEntity = contactCaptor.firstValue
+      assertThat(updatingEntity.verifiedTime).isInThePast()
+    }
+  }
 }
 
 private fun updateContactAddressRequest() =
@@ -482,6 +952,27 @@ private fun updateContactAddressRequest() =
     postcode = "CV4 9NJ",
     countryCode = "UK",
     updatedBy = "TEST",
+  )
+
+private fun patchContactAddressRequest() =
+  PatchContactAddressRequest(
+    addressType = JsonNullable.of("HOME"),
+    primaryAddress = JsonNullable.of(false),
+    flat = JsonNullable.of("13"),
+    property = JsonNullable.of("13"),
+    street = JsonNullable.of("Main Street"),
+    area = JsonNullable.of("Dodworth"),
+    cityCode = JsonNullable.of("CVNTRY"),
+    countyCode = JsonNullable.of("WARWKS"),
+    postcode = JsonNullable.of("CV4 9NJ"),
+    countryCode = JsonNullable.of("UK"),
+    verified = JsonNullable.of(false),
+    mailFlag = JsonNullable.of(false),
+    startDate = JsonNullable.of(LocalDate.of(2000, 12, 25)),
+    endDate = JsonNullable.of(LocalDate.of(2001, 12, 25)),
+    noFixedAddress = JsonNullable.of(false),
+    comments = JsonNullable.of("UK"),
+    updatedBy = "System",
   )
 
 private fun createContactAddressRequest() =
@@ -512,12 +1003,12 @@ private fun contactEntity(contactId: Long = 1L) =
     createdBy = "TEST",
   )
 
-private fun contactAddressEntity() =
+private fun contactAddressEntity(contactId: Long = 1L, contactAddressId: Long = 1L, primaryAddress: Boolean = true) =
   ContactAddressEntity(
-    contactAddressId = 1L,
-    contactId = 1L,
+    contactAddressId = contactAddressId,
+    contactId = contactId,
     addressType = "HOME",
-    primaryAddress = true,
+    primaryAddress = primaryAddress,
     flat = "1B",
     property = "Mason House",
     street = "Main Street",
@@ -562,6 +1053,29 @@ private fun UpdateContactAddressRequest.toEntity(contactId: Long, contactAddress
     countyCode = this.countyCode,
     postCode = this.postcode,
     countryCode = this.countryCode,
+    createdBy = "TEST",
+  ).also {
+    it.updatedBy = updatedBy
+    it.updatedTime = LocalDateTime.now()
+  }
+}
+
+private fun PatchContactAddressRequest.toEntity(contactId: Long, contactAddressId: Long = 1L): ContactAddressEntity {
+  val updatedBy = this.updatedBy
+
+  return ContactAddressEntity(
+    contactAddressId = contactAddressId,
+    contactId = contactId,
+    addressType = this.addressType.orElse(""),
+    primaryAddress = this.primaryAddress.orElse(true),
+    flat = this.flat.orElse(""),
+    property = this.property.orElse(""),
+    street = this.street.orElse(""),
+    area = this.area.orElse(""),
+    cityCode = this.cityCode.orElse(""),
+    countyCode = this.countyCode.orElse(""),
+    postCode = this.postcode.orElse(""),
+    countryCode = this.countryCode.orElse(""),
     createdBy = "TEST",
   ).also {
     it.updatedBy = updatedBy


### PR DESCRIPTION
The manage address journeys should be individual “bounce” pages so it would be better to have a PATCH API that allows us to update only the relevant fields to each page (type, address lines, meta data).