### PR TITLE
PRC-387: Standardise validation of reference codes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/ReferenceCodeGroup.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/ReferenceCodeGroup.kt
@@ -3,20 +3,20 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.model
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(enumAsRef = true)
-enum class ReferenceCodeGroup(val isDocumented: Boolean) {
-  DOMESTIC_STS(true),
-  OFF_RELATION(true),
-  ID_TYPE(true),
-  LANGUAGE(true),
-  GENDER(true),
-  RELATIONSHIP(true),
-  CITY(true),
-  COUNTY(true),
-  CONTACT_TYPE(true),
-  COUNTRY(true),
-  ADDRESS_TYPE(true),
-  PHONE_TYPE(true),
-  RESTRICTION(true),
-  TITLE(true),
-  TEST_TYPE(false),
+enum class ReferenceCodeGroup(val displayName: String, val isDocumented: Boolean) {
+  DOMESTIC_STS("domestic status", true),
+  OFF_RELATION("official relationship", true),
+  ID_TYPE("identity type", true),
+  LANGUAGE("language", true),
+  GENDER("gender", true),
+  RELATIONSHIP("relationship type", true),
+  CITY("city", true),
+  COUNTY("county", true),
+  CONTACT_TYPE("contact type", true),
+  COUNTRY("country", true),
+  ADDRESS_TYPE("address type", true),
+  PHONE_TYPE("phone type", true),
+  RESTRICTION("restriction type", true),
+  TITLE("title", true),
+  TEST_TYPE("test type", false),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPatchService.kt
@@ -15,7 +15,6 @@ import java.time.LocalDateTime
 @Service
 class ContactPatchService(
   private val contactRepository: ContactRepository,
-  private val languageService: LanguageService,
   private val referenceCodeService: ReferenceCodeService,
 ) {
 
@@ -59,7 +58,8 @@ class ContactPatchService(
 
   private fun validateLanguageCode(request: PatchContactRequest) {
     if (request.languageCode.isPresent && request.languageCode.get() != null) {
-      languageService.getLanguageByNomisCode(request.languageCode.get()!!)
+      val code = request.languageCode.get()!!
+      referenceCodeService.validateReferenceCode(ReferenceCodeGroup.LANGUAGE, code, allowInactive = true)
     }
   }
 
@@ -78,29 +78,21 @@ class ContactPatchService(
   private fun validateDomesticStatusCode(request: PatchContactRequest) {
     if (request.domesticStatus.isPresent && request.domesticStatus.get() != null) {
       val code = request.domesticStatus.get()!!
-      referenceCodeService.getReferenceDataByGroupAndCode(
-        ReferenceCodeGroup.DOMESTIC_STS, code,
-      )
-        ?: throw ValidationException("Reference code with groupCode DOMESTIC_STS and code '$code' not found.")
+      referenceCodeService.validateReferenceCode(ReferenceCodeGroup.DOMESTIC_STS, code, allowInactive = true)
     }
   }
 
   private fun validateTitle(request: PatchContactRequest) {
     if (request.title.isPresent && request.title.get() != null) {
       val code = request.title.get()!!
-      referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.TITLE, code)
-        ?: throw ValidationException("Reference code with groupCode TITLE and code '$code' not found.")
+      referenceCodeService.validateReferenceCode(ReferenceCodeGroup.TITLE, code, allowInactive = true)
     }
   }
 
   private fun validateGender(request: PatchContactRequest) {
     if (request.gender.isPresent && request.gender.get() != null) {
       val code = request.gender.get()!!
-      val referenceData = referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.GENDER, code)
-      when {
-        referenceData == null -> throw ValidationException("Reference code with groupCode GENDER and code '$code' not found.")
-        !referenceData.isActive -> throw ValidationException("Reference code with groupCode GENDER and code '$code' is not active and is no longer supported.")
-      }
+      referenceCodeService.validateReferenceCode(ReferenceCodeGroup.GENDER, code, allowInactive = true)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneService.kt
@@ -29,7 +29,7 @@ class ContactPhoneService(
   @Transactional
   fun create(contactId: Long, request: CreatePhoneRequest): ContactPhoneDetails {
     validateContactExists(contactId)
-    val type = validatePhoneType(request.phoneType)
+    val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, request.phoneType, allowInactive = false)
     validatePhoneNumber(request.phoneNumber)
     val created = contactPhoneRepository.saveAndFlush(
       ContactPhoneEntity(
@@ -52,7 +52,7 @@ class ContactPhoneService(
   fun update(contactId: Long, contactPhoneId: Long, request: UpdatePhoneRequest): ContactPhoneDetails {
     validateContactExists(contactId)
     val existing = validateExistingPhone(contactPhoneId)
-    val type = validatePhoneType(request.phoneType)
+    val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, request.phoneType, allowInactive = true)
     validatePhoneNumber(request.phoneNumber)
 
     val updating = existing.copy(
@@ -86,14 +86,6 @@ class ContactPhoneService(
     if (!phoneNumber.matches(Regex("\\+?[\\d\\s()]+"))) {
       throw ValidationException("Phone number invalid, it can only contain numbers, () and whitespace with an optional + at the start")
     }
-  }
-
-  private fun validatePhoneType(phoneType: String): ReferenceCode {
-    val type = referenceCodeService.getReferenceDataByGroupAndCode(
-      ReferenceCodeGroup.PHONE_TYPE, phoneType,
-    )
-      ?: throw ValidationException("Unsupported phone type ($phoneType)")
-    return type
   }
 
   private fun validateContactExists(contactId: Long) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/RestrictionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/RestrictionsService.kt
@@ -102,7 +102,7 @@ class RestrictionsService(
     validateContactExists(contactId)
     validateExpiryDateBeforeStartDate(request.startDate, request.expiryDate)
 
-    val type = validateType(request.restrictionType)
+    val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.RESTRICTION, request.restrictionType, allowInactive = false)
     val created = contactRestrictionRepository.saveAndFlush(
       ContactRestrictionEntity(
         contactRestrictionId = 0,
@@ -132,7 +132,7 @@ class RestrictionsService(
     validateExpiryDateBeforeStartDate(request.startDate, request.expiryDate)
     val contactRestriction = contactRestrictionRepository.findById(contactRestrictionId)
       .orElseThrow { EntityNotFoundException("Contact restriction ($contactRestrictionId) could not be found") }
-    val type = validateType(request.restrictionType)
+    val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.RESTRICTION, request.restrictionType, allowInactive = true)
     val updated = contactRestrictionRepository.saveAndFlush(
       contactRestriction.copy(
         restrictionType = request.restrictionType,
@@ -175,7 +175,7 @@ class RestrictionsService(
   ): PrisonerContactRestrictionDetails {
     val relationship = prisonerContactRepository.findById(prisonerContactId)
       .orElseThrow { EntityNotFoundException("Prisoner contact ($prisonerContactId) could not be found") }
-    val type = validateType(request.restrictionType)
+    val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.RESTRICTION, request.restrictionType, allowInactive = false)
     val created = prisonerContactRestrictionRepository.saveAndFlush(
       PrisonerContactRestrictionEntity(
         prisonerContactRestrictionId = 0,
@@ -199,7 +199,7 @@ class RestrictionsService(
       .orElseThrow { EntityNotFoundException("Prisoner contact ($prisonerContactId) could not be found") }
     val prisonerContactRestriction = prisonerContactRestrictionRepository.findById(prisonerContactRestrictionId)
       .orElseThrow { EntityNotFoundException("Prisoner contact restriction ($prisonerContactRestrictionId) could not be found") }
-    val type = validateType(request.restrictionType)
+    val type = referenceCodeService.validateReferenceCode(ReferenceCodeGroup.RESTRICTION, request.restrictionType, allowInactive = true)
     val updated = prisonerContactRestrictionRepository.saveAndFlush(
       prisonerContactRestriction.copy(
         restrictionType = request.restrictionType,
@@ -242,16 +242,5 @@ class RestrictionsService(
   private fun validateContactExists(contactId: Long) {
     contactRepository.findById(contactId)
       .orElseThrow { EntityNotFoundException("Contact ($contactId) could not be found") }
-  }
-
-  private fun validateType(restrictionType: String): ReferenceCode {
-    val referenceCode = referenceCodeService.getReferenceDataByGroupAndCode(
-      ReferenceCodeGroup.RESTRICTION, restrictionType,
-    )
-      ?: throw ValidationException("Unsupported restriction type ($restrictionType)")
-    if (!referenceCode.isActive) {
-      throw ValidationException("Restriction type ($restrictionType) is no longer supported for creating or updating restrictions")
-    }
-    return referenceCode
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactIdentityIntegrationTest.kt
@@ -184,7 +184,7 @@ class CreateContactIdentityIntegrationTest : H2IntegrationTestBase() {
       .expectBody(ErrorResponse::class.java)
       .returnResult().responseBody!!
 
-    assertThat(errors.userMessage).isEqualTo("Validation failure: Identity type (NHS) is no longer supported for creating or updating identities")
+    assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported identity type (NHS). This code is no longer active.")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/CreateContactWithRelationshipIntegrationTest.kt
@@ -118,7 +118,7 @@ class CreateContactWithRelationshipIntegrationTest : H2IntegrationTestBase() {
       .expectBody(ErrorResponse::class.java)
       .returnResult().responseBody!!
 
-    assertThat(errors.userMessage).isEqualTo("Validation failure: Reference code with groupCode RELATIONSHIP and code 'FOO' not found.")
+    assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported relationship type (FOO)")
     stubEvents.assertHasNoEvents(event = OutboundEvent.CONTACT_CREATED)
     stubEvents.assertHasNoEvents(event = OutboundEvent.PRISONER_CONTACT_CREATED)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/PatchContactIntegrationTest.kt
@@ -683,7 +683,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
         .build()
         .toUri()
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
-      assertThat(errors.userMessage).isEqualTo("Validation failure: Reference code with groupCode TITLE and code 'FOO' not found.")
+      assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported title (FOO)")
 
       stubEvents.assertHasNoEvents(
         event = OutboundEvent.CONTACT_UPDATED,
@@ -793,23 +793,7 @@ class PatchContactIntegrationTest : H2IntegrationTestBase() {
         .build()
         .toUri()
       val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
-      assertThat(errors.userMessage).isEqualTo("Validation failure: Reference code with groupCode GENDER and code 'FOO' not found.")
-
-      stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactWithAGender, Source.DPS))
-    }
-
-    @Test
-    fun `should not be able to patch to an inactive gender value`() {
-      val req = PatchContactRequest(
-        gender = JsonNullable.of("REF"),
-        updatedBy = updatedByUser,
-      )
-
-      val uri = UriComponentsBuilder.fromPath("/contact/$contactWithAGender")
-        .build()
-        .toUri()
-      val errors = testAPIClient.getBadResponseErrorsWithPatch(req, uri)
-      assertThat(errors.userMessage).isEqualTo("Validation failure: Reference code with groupCode GENDER and code 'REF' is not active and is no longer supported.")
+      assertThat(errors.userMessage).isEqualTo("Validation failure: Unsupported gender (FOO)")
 
       stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_UPDATED, ContactInfo(contactWithAGender, Source.DPS))
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/ReferenceCodesResourceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/ReferenceCodesResourceIntegrationTest.kt
@@ -47,7 +47,7 @@ class ReferenceCodesResourceIntegrationTest : H2IntegrationTestBase() {
   }
 
   @Test
-  fun `should return empty list if no matching code found`() {
+  fun `should return bad request if no matching code found`() {
     val error = webTestClient.get()
       .uri("/reference-codes/group/FOO")
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/UpdateContactIdentityIntegrationTest.kt
@@ -179,31 +179,6 @@ class UpdateContactIdentityIntegrationTest : H2IntegrationTestBase() {
   }
 
   @Test
-  fun `should not update the identity if the type is no longer active`() {
-    val request = UpdateIdentityRequest(
-      identityType = "NHS",
-      identityValue = "Is active is false",
-      updatedBy = "updated",
-    )
-
-    val errors = webTestClient.put()
-      .uri("/contact/$savedContactId/identity/$savedContactIdentityId")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CONTACTS_ADMIN")))
-      .bodyValue(request)
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody!!
-
-    assertThat(errors.userMessage).isEqualTo("Validation failure: Identity type (NHS) is no longer supported for creating or updating identities")
-    stubEvents.assertHasNoEvents(OutboundEvent.CONTACT_IDENTITY_UPDATED, ContactIdentityInfo(savedContactIdentityId))
-  }
-
-  @Test
   fun `should not update the identity if the contact is not found`() {
     val request = aMinimalRequest()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactIdentityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactIdentityServiceTest.kt
@@ -69,40 +69,24 @@ class ContactIdentityServiceTest {
     }
 
     @Test
-    fun `should throw ValidationException creating identity if identity type doesn't exist`() {
+    fun `should throw ValidationException creating identity if identity type is invalid`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "FOO")).thenReturn(null)
+      val expectedException = ValidationException("Unsupported identity type (FOO)")
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "FOO", allowInactive = false)).thenThrow(
+        expectedException,
+      )
 
       val exception = assertThrows<ValidationException> {
         service.create(contactId, request.copy(identityType = "FOO"))
       }
-      assertThat(exception.message).isEqualTo("Unsupported identity type (FOO)")
-    }
-
-    @Test
-    fun `should throw ValidationException creating identity if identity type is no longer active`() {
-      whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "NHS")).thenReturn(
-        ReferenceCode(
-          0,
-          ReferenceCodeGroup.ID_TYPE,
-          "NHS",
-          "NHS Number",
-          0,
-          false,
-        ),
-      )
-
-      val exception = assertThrows<ValidationException> {
-        service.create(contactId, request.copy(identityType = "NHS"))
-      }
-      assertThat(exception.message).isEqualTo("Identity type (NHS) is no longer supported for creating or updating identities")
+      assertThat(exception).isEqualTo(expectedException)
+      verify(referenceCodeService).validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "FOO", allowInactive = false)
     }
 
     @Test
     fun `should throw ValidationException if identity type is PNC but identity is not a valid PNC`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "PNC")).thenReturn(
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "PNC", allowInactive = false)).thenReturn(
         ReferenceCode(
           0,
           ReferenceCodeGroup.ID_TYPE,
@@ -122,7 +106,7 @@ class ContactIdentityServiceTest {
     @Test
     fun `should return identity details including the reference data after creating successfully`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "DL")).thenReturn(
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "DL", allowInactive = false)).thenReturn(
         ReferenceCode(
           0,
           ReferenceCodeGroup.ID_TYPE,
@@ -201,43 +185,24 @@ class ContactIdentityServiceTest {
     }
 
     @Test
-    fun `should throw ValidationException updating identity if identity type doesn't exist`() {
+    fun `should throw ValidationException updating identity if identity type is invalid`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactIdentityRepository.findById(contactIdentityId)).thenReturn(Optional.of(existingIdentity))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "FOO")).thenReturn(null)
+      val expectedException = ValidationException("Unsupported identity type (FOO)")
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "FOO", allowInactive = true)).thenThrow(expectedException)
 
       val exception = assertThrows<ValidationException> {
         service.update(contactId, contactIdentityId, request.copy(identityType = "FOO"))
       }
-      assertThat(exception.message).isEqualTo("Unsupported identity type (FOO)")
-    }
-
-    @Test
-    fun `should throw ValidationException updating identity if identity type is no longer active`() {
-      whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(contactIdentityRepository.findById(contactIdentityId)).thenReturn(Optional.of(existingIdentity))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "NHS")).thenReturn(
-        ReferenceCode(
-          0,
-          ReferenceCodeGroup.ID_TYPE,
-          "NHS",
-          "NHS Number",
-          0,
-          false,
-        ),
-      )
-
-      val exception = assertThrows<ValidationException> {
-        service.update(contactId, contactIdentityId, request.copy(identityType = "NHS"))
-      }
-      assertThat(exception.message).isEqualTo("Identity type (NHS) is no longer supported for creating or updating identities")
+      assertThat(exception).isEqualTo(expectedException)
+      verify(referenceCodeService).validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "FOO", allowInactive = true)
     }
 
     @Test
     fun `should throw ValidationException if identity type is PNC but identity is not a valid PNC`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactIdentityRepository.findById(contactIdentityId)).thenReturn(Optional.of(existingIdentity))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "PNC")).thenReturn(
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "PNC", allowInactive = true)).thenReturn(
         ReferenceCode(
           0,
           ReferenceCodeGroup.ID_TYPE,
@@ -258,7 +223,7 @@ class ContactIdentityServiceTest {
     fun `should return a identity details including the reference data after updating a identity successfully`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactIdentityRepository.findById(contactIdentityId)).thenReturn(Optional.of(existingIdentity))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.ID_TYPE, "PASS")).thenReturn(
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.ID_TYPE, "PASS", allowInactive = true)).thenReturn(
         ReferenceCode(
           0,
           ReferenceCodeGroup.ID_TYPE,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactPhoneServiceTest.kt
@@ -73,14 +73,15 @@ class ContactPhoneServiceTest {
     }
 
     @Test
-    fun `should throw ValidationException creating phone if phone type doesn't exist`() {
+    fun `should throw ValidationException creating phone if phone type is invalid`() {
+      val expectedException = ValidationException("Invalid")
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.PHONE_TYPE, "FOO")).thenReturn(null)
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, "FOO", allowInactive = false)).thenThrow(expectedException)
 
       val exception = assertThrows<ValidationException> {
         service.create(contactId, request.copy(phoneType = "FOO"))
       }
-      assertThat(exception.message).isEqualTo("Unsupported phone type (FOO)")
+      assertThat(exception).isEqualTo(expectedException)
     }
 
     @ParameterizedTest
@@ -134,7 +135,7 @@ class ContactPhoneServiceTest {
     @Test
     fun `should return a phone details including the reference data after creating a contact successfully`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.PHONE_TYPE, "MOB")).thenReturn(
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, "MOB", allowInactive = false)).thenReturn(
         ReferenceCode(
           0,
           ReferenceCodeGroup.PHONE_TYPE,
@@ -166,6 +167,7 @@ class ContactPhoneServiceTest {
           updatedTime = null,
         ),
       )
+      verify(referenceCodeService).validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, "MOB", allowInactive = false)
     }
   }
 
@@ -258,15 +260,16 @@ class ContactPhoneServiceTest {
     }
 
     @Test
-    fun `should throw ValidationException updating phone if phone type doesn't exist`() {
+    fun `should throw ValidationException updating phone if phone type is invalid`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactPhoneRepository.findById(contactPhoneId)).thenReturn(Optional.of(existingPhone))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.PHONE_TYPE, "FOO")).thenReturn(null)
+      val expectedException = ValidationException("Invalid")
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, "FOO", allowInactive = true)).thenThrow(expectedException)
 
       val exception = assertThrows<ValidationException> {
         service.update(contactId, contactPhoneId, request.copy(phoneType = "FOO"))
       }
-      assertThat(exception.message).isEqualTo("Unsupported phone type (FOO)")
+      assertThat(exception).isEqualTo(expectedException)
     }
 
     @ParameterizedTest
@@ -322,7 +325,7 @@ class ContactPhoneServiceTest {
     fun `should return a phone details including the reference data after updating a phone successfully`() {
       whenever(contactRepository.findById(contactId)).thenReturn(Optional.of(aContact))
       whenever(contactPhoneRepository.findById(contactPhoneId)).thenReturn(Optional.of(existingPhone))
-      whenever(referenceCodeService.getReferenceDataByGroupAndCode(ReferenceCodeGroup.PHONE_TYPE, "MOB")).thenReturn(
+      whenever(referenceCodeService.validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, "MOB", allowInactive = true)).thenReturn(
         ReferenceCode(
           0,
           ReferenceCodeGroup.PHONE_TYPE,
@@ -354,6 +357,7 @@ class ContactPhoneServiceTest {
           updatedTime = updated.updatedTime,
         ),
       )
+      verify(referenceCodeService).validateReferenceCode(ReferenceCodeGroup.PHONE_TYPE, "MOB", allowInactive = true)
     }
   }
 


### PR DESCRIPTION
Added missing validation for relationship type on creating contact.

Fixed issues with updating types when the reference code is no longer active (should be allowed).

Fixed issue with deleting phone number if the reference code for phone type was no longer active.