### PR TITLE
PRC-405: Entities for organisations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/BaseOrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/BaseOrganisationEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+import java.time.LocalDateTime.now
+
+@MappedSuperclass
+abstract class BaseOrganisationEntity(
+
+  open val organisationName: String,
+
+  open val programmeNumber: String?,
+
+  open val vatNumber: String?,
+
+  open val caseloadId: String?,
+
+  open val comments: String?,
+
+  @Column(updatable = false)
+  open val createdBy: String,
+
+  @Column(updatable = false)
+  @CreationTimestamp
+  open val createdTime: LocalDateTime = now(),
+
+  open val updatedBy: String?,
+
+  open val updatedTime: LocalDateTime?,
+) {
+  abstract fun id(): Long
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/EmploymentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/EmploymentEntity.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "employment")
+data class EmploymentEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val employmentId: Long,
+
+  val organisationId: Long,
+
+  val contactId: Long,
+
+  val active: Boolean,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressEntity.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "organisation_address")
+data class OrganisationAddressEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationAddressId: Long,
+
+  val organisationId: Long,
+
+  val addressType: String?,
+
+  val primaryAddress: Boolean,
+
+  val mailAddress: Boolean,
+
+  val serviceAddress: Boolean,
+
+  val noFixedAddress: Boolean,
+
+  val flat: String?,
+
+  val property: String?,
+
+  val street: String?,
+
+  val area: String?,
+
+  val cityCode: String?,
+
+  val countyCode: String?,
+
+  val postCode: String?,
+
+  val countryCode: String?,
+
+  val specialNeedsCode: String?,
+
+  val contactPersonName: String?,
+
+  val businessHours: String?,
+
+  val comments: String?,
+
+  val startDate: LocalDate?,
+
+  val endDate: LocalDate?,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressPhoneEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressPhoneEntity.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "organisation_address_phone")
+data class OrganisationAddressPhoneEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationAddressPhoneId: Long,
+
+  val organisationId: Long,
+
+  val organisationPhoneId: Long,
+
+  val organisationAddressId: Long,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationEmailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationEmailEntity.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "organisation_email")
+data class OrganisationEmailEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationEmailId: Long,
+
+  val organisationId: Long,
+
+  val emailAddress: String,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationEntity.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * If making changes to this class they should be reflected in BaseOrganisationEntity and OrganisationWithFixedIdEntity as well.
+ *
+ * Generates a new id using the identity column. If syncing from NOMIS you should use OrganisationWithFixedIdEntity
+ * instead which will not use the sequence and instead provide a specific value from NOMIS corporate_id.
+ *
+ * DPS organisation_id is >= 20000000 and NOMIS corporate_id is < 20000000.
+ */
+@Entity
+@Table(name = "organisation")
+data class OrganisationEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationId: Long? = null,
+  override val organisationName: String,
+  override val programmeNumber: String?,
+  override val vatNumber: String?,
+  override val caseloadId: String?,
+  override val comments: String?,
+  override val createdBy: String,
+  override val createdTime: LocalDateTime,
+  override val updatedBy: String?,
+  override val updatedTime: LocalDateTime?,
+) : BaseOrganisationEntity(
+  organisationName = organisationName,
+  programmeNumber = programmeNumber,
+  vatNumber = vatNumber,
+  caseloadId = caseloadId,
+  comments = comments,
+  createdBy = createdBy,
+  createdTime = createdTime,
+  updatedBy = updatedBy,
+  updatedTime = updatedTime,
+) {
+  override fun id(): Long = requireNotNull(this.organisationId) { "Contact id should be non-null once created" }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationPhoneEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationPhoneEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "organisation_phone")
+data class OrganisationPhoneEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationPhoneId: Long,
+
+  val organisationId: Long,
+
+  val phoneType: String,
+
+  val phoneNumber: String,
+
+  val extNumber: String?,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeEntity.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "organisation_type")
+data class OrganisationTypeEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationTypeId: Long,
+
+  val organisationId: Long,
+
+  val organisationType: String,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationWebAddressEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationWebAddressEntity.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "organisation_web_address")
+data class OrganisationWebAddressEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val organisationWebAddressId: Long,
+
+  val organisationId: Long,
+
+  val webAddress: String,
+
+  val createdBy: String,
+
+  @CreationTimestamp
+  val createdTime: LocalDateTime,
+
+  val updatedBy: String?,
+
+  val updatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationWithFixedIdEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationWithFixedIdEntity.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * If making changes to this class they should be reflected in BaseOrganisationEntity and OrganisationEntity as well.
+ *
+ * The id is manually specified using NOMIS corporate_id. If generating a new organisation on DPS you should use OrganisationEntity
+ * instead which will generate a new id automatically.
+ *
+ * DPS organisation_id is >= 20000000 and NOMIS corporate_id is < 20000000.
+ */
+@Entity
+@Table(name = "organisation")
+data class OrganisationWithFixedIdEntity(
+  @Id
+  val organisationId: Long,
+  override val organisationName: String,
+  override val programmeNumber: String?,
+  override val vatNumber: String?,
+  override val caseloadId: String?,
+  override val comments: String?,
+  override val createdBy: String,
+  override val createdTime: LocalDateTime,
+  override val updatedBy: String?,
+  override val updatedTime: LocalDateTime?,
+) : BaseOrganisationEntity(
+  organisationName = organisationName,
+  programmeNumber = programmeNumber,
+  vatNumber = vatNumber,
+  caseloadId = caseloadId,
+  comments = comments,
+  createdBy = createdBy,
+  createdTime = createdTime,
+  updatedBy = updatedBy,
+  updatedTime = updatedTime,
+) {
+  override fun id(): Long = organisationId
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/EmploymentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/EmploymentRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
+
+@Repository
+interface EmploymentRepository : JpaRepository<EmploymentEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressPhoneRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressPhoneEntity
+
+@Repository
+interface OrganisationAddressPhoneRepository : JpaRepository<OrganisationAddressPhoneEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressEntity
+
+@Repository
+interface OrganisationAddressRepository : JpaRepository<OrganisationAddressEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationEmailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationEmailRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEntity
+
+@Repository
+interface OrganisationEmailRepository : JpaRepository<OrganisationEmailEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationPhoneRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEntity
+
+@Repository
+interface OrganisationPhoneRepository : JpaRepository<OrganisationPhoneEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEntity
+
+@Repository
+interface OrganisationRepository : JpaRepository<OrganisationEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
+
+@Repository
+interface OrganisationTypeRepository : JpaRepository<OrganisationTypeEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWebAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWebAddressRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddressEntity
+
+@Repository
+interface OrganisationWebAddressRepository : JpaRepository<OrganisationWebAddressEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWithFixedIdRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWithFixedIdRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWithFixedIdEntity
+
+@Repository
+interface OrganisationWithFixedIdRepository : JpaRepository<OrganisationWithFixedIdEntity, Long>

--- a/src/main/resources/migrations/common/V2025.01.13.7__org_cleanup.sql
+++ b/src/main/resources/migrations/common/V2025.01.13.7__org_cleanup.sql
@@ -1,0 +1,20 @@
+--
+-- Removing contact_person_name as this is actually on the address rather than organisation. All values are null in NOMIS.
+--
+ALTER TABLE organisation DROP COLUMN contact_person_name;
+
+--
+-- Removing referential integrity on the employment table. This is to allow for the initial migration of contacts
+-- and organisations to happen in any order.
+--
+ALTER TABLE employment DROP CONSTRAINT IF EXISTS employment_organisation_id_fkey;
+ALTER TABLE employment DROP CONSTRAINT IF EXISTS employment_contact_id_fkey;
+
+--
+-- Rename primary key column of organisation_web_address
+--
+ALTER TABLE organisation_web_address DROP CONSTRAINT organisation_web_id_pk;
+ALTER TABLE organisation_web_address RENAME COLUMN organisation_web_id TO organisation_web_address_id;
+ALTER TABLE organisation_web_address ADD CONSTRAINT organisation_web_address_id_pk PRIMARY KEY (organisation_web_address_id) ;
+
+-- End

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/OrganisationEntityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/OrganisationEntityIntegrationTest.kt
@@ -1,0 +1,421 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.db
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressPhoneEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWithFixedIdEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.EmploymentRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationEmailRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationTypeRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationWebAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationWithFixedIdRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * Temporary integration test until APIs are built. This is just to ratify the entity mapping.
+ */
+class OrganisationEntityIntegrationTest : PostgresIntegrationTestBase() {
+
+  @Autowired
+  private lateinit var organisationWithFixedIdRepository: OrganisationWithFixedIdRepository
+
+  @Autowired
+  private lateinit var organisationRepository: OrganisationRepository
+
+  @Autowired
+  private lateinit var organisationTypeRepository: OrganisationTypeRepository
+
+  @Autowired
+  private lateinit var organisationPhoneRepository: OrganisationPhoneRepository
+
+  @Autowired
+  private lateinit var organisationEmailRepository: OrganisationEmailRepository
+
+  @Autowired
+  private lateinit var organisationWebAddressRepository: OrganisationWebAddressRepository
+
+  @Autowired
+  private lateinit var organisationAddressRepository: OrganisationAddressRepository
+
+  @Autowired
+  private lateinit var organisationAddressPhoneRepository: OrganisationAddressPhoneRepository
+
+  @Autowired
+  private lateinit var employmentRepository: EmploymentRepository
+
+  @Test
+  fun `can create an organisation with a fixed id with minimal fields`() {
+    val entity = OrganisationWithFixedIdEntity(
+      12345,
+      organisationName = "Name",
+      programmeNumber = null,
+      vatNumber = null,
+      caseloadId = null,
+      comments = null,
+      createdBy = "Created by",
+      createdTime = LocalDateTime.now(),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val created = organisationWithFixedIdRepository.saveAndFlush(entity)
+    assertThat(created.organisationId).isEqualTo(12345)
+  }
+
+  @Test
+  fun `can create an organisation with a fixed id with optional fields`() {
+    val entity = OrganisationWithFixedIdEntity(
+      654321,
+      organisationName = "Name",
+      programmeNumber = "P1",
+      vatNumber = "V1",
+      caseloadId = "C1",
+      comments = "C2",
+      createdBy = "Created by",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "U1",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val created = organisationWithFixedIdRepository.saveAndFlush(entity)
+    assertThat(created.organisationId).isEqualTo(654321)
+  }
+
+  @Test
+  fun `can create an organisation with a generated id with minimal fields`() {
+    val entity = OrganisationEntity(
+      null,
+      organisationName = "Name",
+      programmeNumber = null,
+      vatNumber = null,
+      caseloadId = null,
+      comments = null,
+      createdBy = "Created by",
+      createdTime = LocalDateTime.now(),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val created = organisationRepository.saveAndFlush(entity)
+    assertThat(created.organisationId).isGreaterThanOrEqualTo(20000000)
+  }
+
+  @Test
+  fun `can create an organisation with a generated id with optional fields`() {
+    val entity = OrganisationEntity(
+      null,
+      organisationName = "Name",
+      programmeNumber = "P1",
+      vatNumber = "V1",
+      caseloadId = "C1",
+      comments = "C2",
+      createdBy = "Created by",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "U1",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val created = organisationRepository.saveAndFlush(entity)
+    assertThat(created.organisationId).isGreaterThanOrEqualTo(20000000)
+  }
+
+  @Test
+  fun `can create organisation types`() {
+    val org = aNewOrganisation()
+    val withMinimalFields = OrganisationTypeEntity(
+      organisationTypeId = 0,
+      organisationId = org.id(),
+      organisationType = "SWO",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = OrganisationTypeEntity(
+      organisationTypeId = 0,
+      organisationId = org.id(),
+      organisationType = "SWO",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = organisationTypeRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.organisationTypeId).isGreaterThan(0)
+    val createdMax = organisationTypeRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.organisationTypeId).isGreaterThan(0)
+  }
+
+  @Test
+  fun `can create organisation phones`() {
+    val org = aNewOrganisation()
+    val withMinimalFields = OrganisationPhoneEntity(
+      organisationPhoneId = 0,
+      organisationId = org.id(),
+      phoneType = "MOB",
+      phoneNumber = "123",
+      extNumber = null,
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = OrganisationPhoneEntity(
+      organisationPhoneId = 0,
+      organisationId = org.id(),
+      phoneType = "HOME",
+      phoneNumber = "321",
+      extNumber = "987",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = organisationPhoneRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.organisationPhoneId).isGreaterThan(0)
+    val createdMax = organisationPhoneRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.organisationPhoneId).isGreaterThan(0)
+  }
+
+  @Test
+  fun `can create organisation emails`() {
+    val org = aNewOrganisation()
+    val withMinimalFields = OrganisationEmailEntity(
+      organisationEmailId = 0,
+      organisationId = org.id(),
+      emailAddress = "test@example.com",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = OrganisationEmailEntity(
+      organisationEmailId = 0,
+      organisationId = org.id(),
+      emailAddress = "more@example.com",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = organisationEmailRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.organisationEmailId).isGreaterThan(0)
+    val createdMax = organisationEmailRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.organisationEmailId).isGreaterThan(0)
+  }
+
+  @Test
+  fun `can create organisation web addresses`() {
+    val org = aNewOrganisation()
+    val withMinimalFields = OrganisationWebAddressEntity(
+      organisationWebAddressId = 0,
+      organisationId = org.id(),
+      webAddress = "test.example.com",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = OrganisationWebAddressEntity(
+      organisationWebAddressId = 0,
+      organisationId = org.id(),
+      webAddress = "more.example.com",
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = organisationWebAddressRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.organisationWebAddressId).isGreaterThan(0)
+    val createdMax = organisationWebAddressRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.organisationWebAddressId).isGreaterThan(0)
+  }
+
+  @Test
+  fun `can create organisation addresses`() {
+    val org = aNewOrganisation()
+    val withMinimalFields = OrganisationAddressEntity(
+      organisationAddressId = 0,
+      organisationId = org.id(),
+      addressType = null,
+      primaryAddress = false,
+      mailAddress = false,
+      serviceAddress = false,
+      noFixedAddress = false,
+      flat = null,
+      property = null,
+      street = null,
+      area = null,
+      cityCode = null,
+      countyCode = null,
+      postCode = null,
+      countryCode = null,
+      specialNeedsCode = null,
+      contactPersonName = null,
+      businessHours = null,
+      comments = null,
+      startDate = null,
+      endDate = null,
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = OrganisationAddressEntity(
+      organisationAddressId = 0,
+      organisationId = org.id(),
+      addressType = "HOME",
+      primaryAddress = true,
+      mailAddress = true,
+      serviceAddress = true,
+      noFixedAddress = true,
+      flat = "F1",
+      property = "P1",
+      street = "S1",
+      area = "A1",
+      cityCode = "25343",
+      countyCode = "S.YORKSHIRE",
+      postCode = "P1C1",
+      countryCode = "ENG",
+      specialNeedsCode = "DEAF",
+      contactPersonName = "CP1",
+      businessHours = "BH1",
+      comments = "Comments",
+      startDate = LocalDate.of(2000, 1, 1),
+      endDate = LocalDate.of(2010, 10, 10),
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = organisationAddressRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.organisationAddressId).isGreaterThan(0)
+    val createdMax = organisationAddressRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.organisationAddressId).isGreaterThan(0)
+  }
+
+  @Test
+  fun `can create organisation address phones`() {
+    val org = aNewOrganisation()
+    val phone = organisationPhoneRepository.saveAndFlush(
+      OrganisationPhoneEntity(
+        organisationPhoneId = 0,
+        organisationId = org.id(),
+        phoneType = "MOB",
+        phoneNumber = "123",
+        extNumber = null,
+        createdBy = "CREATED",
+        createdTime = LocalDateTime.now().minusMinutes(20),
+        updatedBy = null,
+        updatedTime = null,
+      ),
+    )
+    val address = organisationAddressRepository.saveAndFlush(
+      OrganisationAddressEntity(
+        organisationAddressId = 0,
+        organisationId = org.id(),
+        addressType = null,
+        primaryAddress = false,
+        mailAddress = false,
+        serviceAddress = false,
+        noFixedAddress = false,
+        flat = null,
+        property = null,
+        street = null,
+        area = null,
+        cityCode = null,
+        countyCode = null,
+        postCode = null,
+        countryCode = null,
+        specialNeedsCode = null,
+        contactPersonName = null,
+        businessHours = null,
+        comments = null,
+        startDate = null,
+        endDate = null,
+        createdBy = "CREATED",
+        createdTime = LocalDateTime.now().minusMinutes(20),
+        updatedBy = null,
+        updatedTime = null,
+      ),
+    )
+    val withMinimalFields = OrganisationAddressPhoneEntity(
+      organisationAddressPhoneId = 0,
+      organisationId = org.id(),
+      organisationPhoneId = phone.organisationPhoneId,
+      organisationAddressId = address.organisationAddressId,
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = OrganisationAddressPhoneEntity(
+      organisationAddressPhoneId = 0,
+      organisationId = org.id(),
+      organisationPhoneId = phone.organisationPhoneId,
+      organisationAddressId = address.organisationAddressId,
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = organisationAddressPhoneRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.organisationAddressPhoneId).isGreaterThan(0)
+    val createdMax = organisationAddressPhoneRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.organisationAddressPhoneId).isGreaterThan(0)
+  }
+
+  @Test
+  fun `can create employments and no referential integrity is required`() {
+    val withMinimalFields = EmploymentEntity(
+      employmentId = 0,
+      organisationId = 99,
+      contactId = 77,
+      active = false,
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    val withAllFields = EmploymentEntity(
+      employmentId = 0,
+      organisationId = 456,
+      contactId = 789,
+      active = true,
+      createdBy = "CREATED",
+      createdTime = LocalDateTime.now().minusMinutes(20),
+      updatedBy = "UPDATED",
+      updatedTime = LocalDateTime.now().plusMinutes(20),
+    )
+    val createdMin = employmentRepository.saveAndFlush(withMinimalFields)
+    assertThat(createdMin.employmentId).isGreaterThan(0)
+    val createdMax = employmentRepository.saveAndFlush(withAllFields)
+    assertThat(createdMax.employmentId).isGreaterThan(0)
+  }
+
+  private fun aNewOrganisation(): OrganisationEntity {
+    val entity = OrganisationEntity(
+      null,
+      organisationName = "Name",
+      programmeNumber = null,
+      vatNumber = null,
+      caseloadId = null,
+      comments = null,
+      createdBy = "Created by",
+      createdTime = LocalDateTime.now(),
+      updatedBy = null,
+      updatedTime = null,
+    )
+    return organisationRepository.saveAndFlush(entity)
+  }
+}


### PR DESCRIPTION
Includes some clean up of the data model:

 * Rename organisation_web_address pk to organisation_web_address_id
 * Remove contact_person_name from organisation as it's unused
 * Remove constraints on employment table as this allows us to migrate contacts and organisations in any order. This was agreed with syscon for migration purposes.