### PR TITLE
PRC-403: Only return global phone numbers in the phoneNumbers list for a contact.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactByIdIntegrationTest.kt
@@ -127,7 +127,9 @@ class GetContactByIdIntegrationTest : H2IntegrationTestBase() {
 
     with(contact) {
       assertThat(id).isEqualTo(1)
-      assertThat(contact.phoneNumbers).hasSize(2)
+
+      // Phone numbers should exclude any address-specific numbers
+      assertThat(contact.phoneNumbers).hasSize(1)
       with(contact.phoneNumbers[0]) {
         assertThat(contactPhoneId).isEqualTo(1)
         assertThat(contactId).isEqualTo(1)
@@ -136,15 +138,6 @@ class GetContactByIdIntegrationTest : H2IntegrationTestBase() {
         assertThat(phoneNumber).isEqualTo("07878 111111")
         assertThat(extNumber).isNull()
         assertThat(createdBy).isEqualTo("TIM")
-      }
-      with(contact.phoneNumbers[1]) {
-        assertThat(contactPhoneId).isEqualTo(2)
-        assertThat(contactId).isEqualTo(1)
-        assertThat(phoneType).isEqualTo("HOME")
-        assertThat(phoneTypeDescription).isEqualTo("Home")
-        assertThat(phoneNumber).isEqualTo("01111 777777")
-        assertThat(extNumber).isEqualTo("+0123")
-        assertThat(createdBy).isEqualTo("JAMES")
       }
 
       assertThat(contact.addresses).hasSize(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactServiceTest.kt
@@ -365,7 +365,7 @@ class ContactServiceTest {
     }
 
     @Test
-    fun `should get a contact with phone numbers including those attached to addresses`() {
+    fun `should get a contact with phone numbers but exclude those attached to addresses`() {
       val aGeneralPhoneNumber = createContactPhoneDetailsEntity(id = 1, contactId = contactId)
       val aPhoneAttachedToAddress1 = createContactPhoneDetailsEntity(id = 2, contactId = contactId)
       val aPhoneAttachedToAddress2 = createContactPhoneDetailsEntity(id = 3, contactId = contactId)
@@ -398,11 +398,9 @@ class ContactServiceTest {
       with(contact!!) {
         assertThat(id).isEqualTo(entity.contactId)
 
-        assertThat(phoneNumbers).hasSize(4)
+        // Should not include the 3 address-specific phone numbers
+        assertThat(phoneNumbers).hasSize(1)
         assertThat(phoneNumbers[0].contactPhoneId).isEqualTo(1)
-        assertThat(phoneNumbers[1].contactPhoneId).isEqualTo(2)
-        assertThat(phoneNumbers[2].contactPhoneId).isEqualTo(3)
-        assertThat(phoneNumbers[3].contactPhoneId).isEqualTo(4)
 
         assertThat(addresses).hasSize(2)
         assertThat(addresses[0].contactAddressId).isEqualTo(1)


### PR DESCRIPTION
We were formerly including all address-specific numbers as well.
Address specific numbers are now only displayed and managed via editing the address they are associated with.