### PR TITLE
PRC-408: Initial migration endpoint for organisations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/BaseOrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/BaseOrganisationEntity.kt
@@ -2,10 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.MappedSuperclass
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalDateTime.now
 
 @MappedSuperclass
 abstract class BaseOrganisationEntity(
@@ -28,8 +26,7 @@ abstract class BaseOrganisationEntity(
   open val createdBy: String,
 
   @Column(updatable = false)
-  @CreationTimestamp
-  open val createdTime: LocalDateTime = now(),
+  open val createdTime: LocalDateTime,
 
   open val updatedBy: String?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressEntity.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -56,9 +56,10 @@ data class OrganisationAddressEntity(
 
   val endDate: LocalDate?,
 
+  @Column(updatable = false)
   val createdBy: String,
 
-  @CreationTimestamp
+  @Column(updatable = false)
   val createdTime: LocalDateTime,
 
   val updatedBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressPhoneEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationAddressPhoneEntity.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
 @Entity
@@ -21,9 +21,10 @@ data class OrganisationAddressPhoneEntity(
 
   val organisationAddressId: Long,
 
+  @Column(updatable = false)
   val createdBy: String,
 
-  @CreationTimestamp
+  @Column(updatable = false)
   val createdTime: LocalDateTime,
 
   val updatedBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationEmailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationEmailEntity.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
 @Entity
@@ -19,9 +19,10 @@ data class OrganisationEmailEntity(
 
   val emailAddress: String,
 
+  @Column(updatable = false)
   val createdBy: String,
 
-  @CreationTimestamp
+  @Column(updatable = false)
   val createdTime: LocalDateTime,
 
   val updatedBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationPhoneEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationPhoneEntity.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
 @Entity
@@ -23,9 +23,10 @@ data class OrganisationPhoneEntity(
 
   val extNumber: String?,
 
+  @Column(updatable = false)
   val createdBy: String,
 
-  @CreationTimestamp
+  @Column(updatable = false)
   val createdTime: LocalDateTime,
 
   val updatedBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeEntity.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
 @Entity
@@ -19,9 +19,10 @@ data class OrganisationTypeEntity(
 
   val organisationType: String,
 
+  @Column(updatable = false)
   val createdBy: String,
 
-  @CreationTimestamp
+  @Column(updatable = false)
   val createdTime: LocalDateTime,
 
   val updatedBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationWebAddressEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationWebAddressEntity.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.CreationTimestamp
 import java.time.LocalDateTime
 
 @Entity
@@ -19,9 +19,10 @@ data class OrganisationWebAddressEntity(
 
   val webAddress: String,
 
+  @Column(updatable = false)
   val createdBy: String,
 
-  @CreationTimestamp
+  @Column(updatable = false)
   val createdTime: LocalDateTime,
 
   val updatedBy: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/AbstractAuditable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/AbstractAuditable.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+abstract class AbstractAuditable(
+  @Schema(description = "The data and time the record was created", nullable = true, example = "2022-10-01T16:45:45")
+  var createDateTime: LocalDateTime? = null,
+
+  @Schema(description = "The username who created the row", nullable = true, example = "X999X")
+  var createUsername: String? = null,
+
+  @Schema(description = "The date and time the record was last amended", nullable = true, example = "2022-10-01T16:45:45")
+  var modifyDateTime: LocalDateTime? = null,
+
+  @Schema(description = "The username who last modified the row", nullable = true, example = "X999X")
+  var modifyUsername: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateContactRequest.kt
@@ -5,21 +5,6 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
-import java.time.LocalDateTime
-
-abstract class AbstractAuditable(
-  @Schema(description = "The data and time the record was created", nullable = true, example = "2022-10-01T16:45:45")
-  var createDateTime: LocalDateTime? = null,
-
-  @Schema(description = "The username who created the row", nullable = true, example = "X999X")
-  var createUsername: String? = null,
-
-  @Schema(description = "The date and time the record was last amended", nullable = true, example = "2022-10-01T16:45:45")
-  var modifyDateTime: LocalDateTime? = null,
-
-  @Schema(description = "The username who last modified the row", nullable = true, example = "X999X")
-  var modifyUsername: String? = null,
-)
 
 @Schema(description = "Request to migrate a contact and all of its sub-elements from NOMIS into this service")
 data class MigrateContactRequest(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateOrganisationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateOrganisationRequest.kt
@@ -1,0 +1,187 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDate
+
+@Schema(description = "Request to migrate an organisation/corporate and all of its sub-elements from NOMIS into this service")
+data class MigrateOrganisationRequest(
+  @Schema(description = "The corporate ID from NOMIS", example = "1233323")
+  @field:NotNull(message = "The NOMIS corporate ID must be present in the request")
+  val nomisCorporateId: Long,
+
+  @Schema(description = "The name of the organisation", example = "Example Limited", maxLength = 40)
+  @field:Size(max = 40, message = "organisationName must be <= 40 characters")
+  val organisationName: String,
+
+  @Schema(
+    description = "The programme number for the organisation, stored as FEI_NUMBER in NOMIS",
+    example = "1",
+    maxLength = 40,
+  )
+  @field:Size(max = 40, message = "programmeNumber must be <= 40 characters")
+  val programmeNumber: String?,
+
+  @Schema(description = "The VAT number for the organisation, if known", example = "123456", maxLength = 12)
+  @field:Size(max = 12, message = "vatNumber must be <= 12 characters")
+  val vatNumber: String?,
+
+  @Schema(
+    description = "The id of the caseload for this organisation, this is an agency id in NOMIS",
+    example = "BXI",
+    maxLength = 6,
+  )
+  @field:Size(max = 6, message = "caseloadId must be <= 6 characters")
+  val caseloadId: String?,
+
+  @Schema(description = "Any comments on the organisation", example = "Some additional info", maxLength = 240)
+  @field:Size(max = 240, message = "comments must be <= 240 characters")
+  val comments: String?,
+
+  @Schema(description = "Whether the organisation is active or not", example = "true")
+  val active: Boolean,
+
+  @Schema(description = "The date the organisation was deactivated, EXPIRY_DATE in NOMIS", example = "2010-12-30")
+  val deactivatedDate: LocalDate?,
+
+  @Schema(description = "The types of the organisation, CORPORATE_TYPES in NOMIS.", example = "TRUST")
+  val organisationTypes: List<MigrateOrganisationType>,
+
+  @Schema(description = "Phone numbers associated directly with the organisation and it's addresses")
+  val phoneNumbers: List<MigrateOrganisationPhoneNumber>,
+
+  @Schema(description = "Emails associated with the organisation")
+  val emailAddresses: List<MigrateOrganisationEmailAddress>,
+
+  @Schema(description = "Web addresses associated with the organisation")
+  val webAddresses: List<MigrateOrganisationWebAddress>,
+
+  @Schema(description = "Addresses associated with the organisation")
+  val addresses: List<MigrateOrganisationAddress>,
+) : AbstractAuditable()
+
+data class MigrateOrganisationType(
+  @Schema(description = "Type of organisation from reference data")
+  val type: String,
+) : AbstractAuditable()
+
+data class MigrateOrganisationPhoneNumber(
+  @Schema(description = "Unique phone ID in NOMIS", example = "123")
+  val nomisPhoneId: Long,
+
+  @Schema(description = "Telephone number", example = "098989 98989893")
+  @field:NotNull(message = "The phone number must be provided")
+  val number: String,
+
+  @Schema(description = "Extension number (optional)", nullable = true, example = "100")
+  val extension: String? = null,
+
+  @Schema(description = "Type of phone number (from reference data)")
+  val type: String,
+) : AbstractAuditable()
+
+data class MigrateOrganisationEmailAddress(
+  @Schema(description = "Unique email ID in NOMIS", example = "123")
+  val nomisEmailAddressId: Long,
+
+  @Schema(description = "Email address", example = "test@example.com")
+  val email: String,
+) : AbstractAuditable()
+
+data class MigrateOrganisationWebAddress(
+  @Schema(description = "Unique web address ID in NOMIS", example = "123")
+  val nomisWebAddressId: Long,
+
+  @Schema(description = "Email address", example = "www.example.com")
+  val webAddress: String,
+) : AbstractAuditable()
+
+data class MigrateOrganisationAddress(
+  @Schema(description = "Unique address ID in NOMIS", example = "123")
+  val nomisAddressId: Long,
+
+  @Schema(description = "Address type from reference data", nullable = true)
+  val type: String? = null,
+
+  @Schema(description = "Flat number or identifier", nullable = true, example = "1B")
+  val flat: String? = null,
+
+  @Schema(description = "House name or number", nullable = true, example = "43")
+  val premise: String? = null,
+
+  @Schema(description = "Street or road", nullable = true, example = "Main Street")
+  val street: String? = null,
+
+  @Schema(description = "Locality", nullable = true, example = "Keighley")
+  val locality: String? = null,
+
+  @Schema(description = "Postcode", nullable = true, example = "BD12 8RD")
+  val postCode: String? = null,
+
+  @Schema(description = "City - code from reference data", nullable = true)
+  val city: String? = null,
+
+  @Schema(description = "County - code from reference data", nullable = true)
+  val county: String? = null,
+
+  @Schema(description = "Country - code from reference data", nullable = true)
+  val country: String? = null,
+
+  @Schema(
+    description = "If true this address should be considered as no fixed address",
+    nullable = true,
+    example = "false",
+  )
+  val noFixedAddress: Boolean = false,
+
+  @Schema(
+    description = "If true this address should be considered as the primary residential address",
+    nullable = true,
+    example = "true",
+  )
+  val primaryAddress: Boolean = false,
+
+  @Schema(
+    description = "If true this address should be considered for sending mail to",
+    nullable = true,
+    example = "true",
+  )
+  val mailAddress: Boolean = false,
+
+  @Schema(
+    description = "If this is the service address for the organisation",
+    nullable = true,
+    example = "true",
+  )
+  val serviceAddress: Boolean = false,
+
+  @Schema(description = "Comments relating to this address", nullable = true, example = "A comment")
+  val comment: String? = null,
+
+  @Schema(
+    description = "Special needs code for this address from SPECIAL_NEEDS in NOMIS.",
+    nullable = true,
+    example = "DEAF",
+  )
+  val specialNeedsCode: String? = null,
+
+  @Schema(description = "The name of the contact person at this address", nullable = true, example = "Joe Bloggs")
+  val contactPersonName: String? = null,
+
+  @Schema(description = "The business hours for this address", nullable = true, example = "9-5")
+  val businessHours: String? = null,
+
+  @Schema(
+    description = "The date this address should be considered valid from",
+    nullable = true,
+    example = "2018-10-01",
+  )
+  val startDate: LocalDate? = null,
+
+  @Schema(description = "The date this address should be considered valid to", nullable = true, example = "2022-04-04")
+  val endDate: LocalDate? = null,
+
+  @Schema(description = "A list of phone numbers which are linked to this address")
+  val phoneNumbers: List<MigrateOrganisationPhoneNumber> = emptyList(),
+) : AbstractAuditable()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/ElementType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/ElementType.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate
+
+/**
+ * Describes the valid type values for an IdPair object
+ */
+enum class ElementType(val elementType: String) {
+  CONTACT("Contact"),
+  PHONE("Phone"),
+  EMAIL("Email"),
+  ADDRESS("Address"),
+  ADDRESS_PHONE("AddressPhone"),
+  IDENTITY("Identity"),
+  RESTRICTION("Restriction"),
+  PRISONER_CONTACT("PrisonerContact"),
+  PRISONER_CONTACT_RESTRICTION("PrisonerContactRestriction"),
+  EMPLOYMENT("Employment"),
+  ORGANISATION("Organisation"),
+  WEB_ADDRESS("WebAddress"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/IdPair.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/IdPair.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * Class to group together a type and the NOMIS / DPS IDs for it.
+ */
+data class IdPair(
+  @Schema(description = "The category of information returned", example = "PHONE")
+  val elementType: ElementType,
+
+  @Schema(description = "The unique ID for this piece of data provided in the request", example = "123435")
+  val nomisId: Long,
+
+  @Schema(description = "The unique ID created in the DPS contacts service", example = "1234")
+  val dpsId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/MigrateContactResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/MigrateContactResponse.kt
@@ -37,20 +37,6 @@ data class MigrateContactResponse(
 )
 
 /**
- * Class to group together a type and the NOMIS / DPS IDs for it.
- */
-data class IdPair(
-  @Schema(description = "The category of information returned", example = "PHONE")
-  val elementType: ElementType,
-
-  @Schema(description = "The unique ID for this piece of data provided in the request", example = "123435")
-  val nomisId: Long,
-
-  @Schema(description = "The unique ID created in the DPS contacts service", example = "1234")
-  val dpsId: Long,
-)
-
-/**
  * Class to return the IDs for an address and a list of associated phone numbers
  */
 data class AddressAndPhones(
@@ -71,19 +57,3 @@ data class ContactsAndRestrictions(
   @Schema(description = "The pairs of IDs in NOMIS and DPS for relationship-specific restrictions")
   val restrictions: List<IdPair>,
 )
-
-/**
- * Describes the valid type values for an IdPair object
- */
-enum class ElementType(val elementType: String) {
-  CONTACT("Contact"),
-  PHONE("Phone"),
-  EMAIL("Email"),
-  ADDRESS("Address"),
-  ADDRESS_PHONE("AddressPhone"),
-  IDENTITY("Identity"),
-  RESTRICTION("Restriction"),
-  PRISONER_CONTACT("PrisonerContact"),
-  PRISONER_CONTACT_RESTRICTION("PrisonerContactRestriction"),
-  EMPLOYMENT("Employment"),
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/MigrateOrganisationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/MigrateOrganisationResponse.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class MigrateOrganisationResponse(
+
+  @Schema(description = "The pair of IDs for this organisation in NOMIS")
+  val organisation: IdPair,
+
+  @Schema(description = "List of NOMIS and DPS IDs for organisation types.")
+  val organisationTypes: List<MigratedOrganisationType> = emptyList(),
+
+  @Schema(description = "List of Nomis and DPS IDs for phone numbers")
+  val phoneNumbers: List<IdPair> = emptyList(),
+
+  @Schema(description = "List of Nomis and DPS IDs for email addresses")
+  val emailAddresses: List<IdPair> = emptyList(),
+
+  @Schema(description = "List of Nomis and DPS IDs for web addresses")
+  val webAddresses: List<IdPair> = emptyList(),
+
+  @Schema(description = "List of Nomis and DPS IDs for addresses")
+  val addresses: List<MigratedOrganisationAddress> = emptyList(),
+)
+
+data class MigratedOrganisationAddress(
+  @Schema(description = "The pair of IDs for this organisation address in NOMIS")
+  val address: IdPair,
+
+  @Schema(description = "List of Nomis and DPS IDs for email addresses")
+  val phoneNumbers: List<IdPair> = emptyList(),
+)
+
+data class MigratedOrganisationType(
+  @Schema(description = "The type of the organisation from reference data", example = "TRUST")
+  val organisationType: String,
+
+  @Schema(description = "The unique ID created in the DPS contacts service", example = "1234")
+  val dpsId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigrateOrganisationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/migrate/MigrateOrganisationController.kt
@@ -13,32 +13,32 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateContactRequest
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateContactResponse
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.ContactMigrationService
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateOrganisationResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate.OrganisationMigrationService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @Tag(name = "Sync & Migrate")
 @RestController
-@RequestMapping(value = ["migrate/contact"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping(value = ["migrate/organisation"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses
-class MigrateContactController(val migrationService: ContactMigrationService) {
+class MigrateOrganisationController(val migrationService: OrganisationMigrationService) {
 
   @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
-    summary = "Migrate a contact",
-    description = "Migrate a contact from NOMIS with all of its associated data.",
+    summary = "Migrate an organisation",
+    description = "Migrate an organisation from NOMIS with all of its associated data. If an organisation with the same id id already exists it will be replaced",
   )
   @ApiResponses(
     value = [
       ApiResponse(
         responseCode = "200",
-        description = "The contact and associated data was created successfully",
+        description = "The organisation and associated data was created successfully",
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = MigrateContactResponse::class),
+            schema = Schema(implementation = MigrateOrganisationResponse::class),
           ),
         ],
       ),
@@ -47,15 +47,10 @@ class MigrateContactController(val migrationService: ContactMigrationService) {
         description = "The request failed validation with invalid or missing data supplied",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],
       ),
-      ApiResponse(
-        responseCode = "409",
-        description = "Conflict. The request contained a personId which already exists",
-        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
-      ),
     ],
   )
   @PreAuthorize("hasAnyRole('ROLE_CONTACTS_MIGRATION')")
-  fun migrateContact(
-    @Valid @RequestBody migrateContactRequest: MigrateContactRequest,
-  ) = migrationService.migrateContact(migrateContactRequest)
+  fun migrateOrganisation(
+    @Valid @RequestBody request: MigrateOrganisationRequest,
+  ): MigrateOrganisationResponse = migrationService.migrateOrganisation(request)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/ContactMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/ContactMigrationService.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactR
 import java.time.LocalDateTime
 
 @Service
-class MigrationService(
+class ContactMigrationService(
   private val contactRepository: ContactWithFixedIdRepository,
   private val contactAddressRepository: ContactAddressRepository,
   private val contactAddressPhoneRepository: ContactAddressPhoneRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/OrganisationMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/OrganisationMigrationService.kt
@@ -1,0 +1,245 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.service.migrate
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressPhoneEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddressEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWithFixedIdEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationEmailAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationPhoneNumber
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationWebAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.ElementType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.IdPair
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateOrganisationResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigratedOrganisationAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigratedOrganisationType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationEmailRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationTypeRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationWebAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationWithFixedIdRepository
+import java.time.LocalDateTime
+
+@Service
+class OrganisationMigrationService(
+  private val organisationRepository: OrganisationWithFixedIdRepository,
+  private val organisationTypeRepository: OrganisationTypeRepository,
+  private val organisationPhoneRepository: OrganisationPhoneRepository,
+  private val organisationEmailRepository: OrganisationEmailRepository,
+  private val organisationWebAddressRepository: OrganisationWebAddressRepository,
+  private val organisationAddressRepository: OrganisationAddressRepository,
+  private val organisationAddressPhoneRepository: OrganisationAddressPhoneRepository,
+) {
+  companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  fun migrateOrganisation(request: MigrateOrganisationRequest): MigrateOrganisationResponse {
+    logger.info(
+      "Migrate organisation ID {} with {} addresses, {} phones, {} emails, {} web addresses, {} types",
+      request.nomisCorporateId,
+      request.addresses.size,
+      request.phoneNumbers.size,
+      request.emailAddresses.size,
+      request.webAddresses.size,
+      request.organisationTypes.size,
+    )
+
+    val organisation = createOrganisation(request)
+    val createdOrganisation = IdPair(
+      ElementType.ORGANISATION,
+      request.nomisCorporateId,
+      organisation.organisationId,
+    )
+    val createdOrganisationTypes = request.organisationTypes.map {
+      MigratedOrganisationType(
+        it.type,
+        createOrganisationType(organisation, it).organisationTypeId,
+      )
+    }
+    val createdPhoneNumbers = request.phoneNumbers.map {
+      IdPair(
+        ElementType.PHONE,
+        it.nomisPhoneId,
+        createOrganisationPhoneNumber(organisation, it).organisationPhoneId,
+      )
+    }
+    val createdEmailAddresses = request.emailAddresses.map {
+      IdPair(
+        ElementType.EMAIL,
+        it.nomisEmailAddressId,
+        createOrganisationEmail(organisation, it).organisationEmailId,
+      )
+    }
+    val createdWebAddresses = request.webAddresses.map {
+      IdPair(
+        ElementType.WEB_ADDRESS,
+        it.nomisWebAddressId,
+        createOrganisationWebAddress(organisation, it).organisationWebAddressId,
+      )
+    }
+
+    val createdAddresses = request.addresses.map {
+      val address = organisationAddressRepository.saveAndFlush(
+        OrganisationAddressEntity(
+          organisationAddressId = 0,
+          organisationId = organisation.id(),
+          addressType = it.type,
+          primaryAddress = it.primaryAddress,
+          mailAddress = it.mailAddress,
+          serviceAddress = it.serviceAddress,
+          noFixedAddress = it.noFixedAddress,
+          flat = it.flat,
+          property = it.premise,
+          street = it.street,
+          area = it.locality,
+          cityCode = it.city,
+          countyCode = it.county,
+          postCode = it.postCode,
+          countryCode = it.country,
+          specialNeedsCode = it.specialNeedsCode,
+          contactPersonName = it.contactPersonName,
+          businessHours = it.businessHours,
+          comments = it.comment,
+          startDate = it.startDate,
+          endDate = it.endDate,
+          createdBy = it.createUsername ?: "MIGRATION",
+          createdTime = it.createDateTime ?: LocalDateTime.now(),
+          updatedBy = it.modifyUsername,
+          updatedTime = it.modifyDateTime,
+        ),
+      )
+      MigratedOrganisationAddress(
+        IdPair(
+          ElementType.ADDRESS,
+          it.nomisAddressId,
+          address.organisationAddressId,
+        ),
+        phoneNumbers = it.phoneNumbers.map { addressPhoneRequest ->
+          val phone = createOrganisationPhoneNumber(organisation, addressPhoneRequest)
+          IdPair(
+            ElementType.PHONE,
+            addressPhoneRequest.nomisPhoneId,
+            createOrganisationAddressPhone(organisation, phone, address, addressPhoneRequest).organisationAddressPhoneId,
+          )
+        },
+      )
+    }
+    return MigrateOrganisationResponse(
+      createdOrganisation,
+      createdOrganisationTypes,
+      createdPhoneNumbers,
+      createdEmailAddresses,
+      createdWebAddresses,
+      createdAddresses,
+    )
+  }
+
+  private fun createOrganisationAddressPhone(
+    organisation: OrganisationWithFixedIdEntity,
+    phone: OrganisationPhoneEntity,
+    address: OrganisationAddressEntity,
+    it: MigrateOrganisationPhoneNumber,
+  ) = organisationAddressPhoneRepository.saveAndFlush(
+    OrganisationAddressPhoneEntity(
+      organisationAddressPhoneId = 0,
+      organisationId = organisation.id(),
+      organisationPhoneId = phone.organisationPhoneId,
+      organisationAddressId = address.organisationAddressId,
+      createdBy = it.createUsername ?: "MIGRATION",
+      createdTime = it.createDateTime ?: LocalDateTime.now(),
+      updatedBy = it.modifyUsername,
+      updatedTime = it.modifyDateTime,
+    ),
+  )
+
+  private fun createOrganisation(request: MigrateOrganisationRequest) =
+    organisationRepository.saveAndFlush(
+      OrganisationWithFixedIdEntity(
+        request.nomisCorporateId,
+        organisationName = request.organisationName,
+        programmeNumber = request.programmeNumber,
+        vatNumber = request.vatNumber,
+        caseloadId = request.caseloadId,
+        comments = request.comments,
+        active = request.active,
+        deactivatedDate = request.deactivatedDate,
+        createdBy = request.createUsername ?: "MIGRATION",
+        createdTime = request.createDateTime ?: LocalDateTime.now(),
+        updatedBy = request.modifyUsername,
+        updatedTime = request.modifyDateTime,
+      ),
+    )
+
+  private fun createOrganisationType(
+    organisation: OrganisationWithFixedIdEntity,
+    it: MigrateOrganisationType,
+  ) = organisationTypeRepository.saveAndFlush(
+    OrganisationTypeEntity(
+      organisationTypeId = 0,
+      organisationId = organisation.id(),
+      organisationType = it.type,
+      createdBy = it.createUsername ?: "MIGRATION",
+      createdTime = it.createDateTime ?: LocalDateTime.now(),
+      updatedBy = it.modifyUsername,
+      updatedTime = it.modifyDateTime,
+    ),
+  )
+
+  private fun createOrganisationPhoneNumber(
+    organisation: OrganisationWithFixedIdEntity,
+    it: MigrateOrganisationPhoneNumber,
+  ) = organisationPhoneRepository.save(
+    OrganisationPhoneEntity(
+      organisationPhoneId = 0,
+      organisationId = organisation.id(),
+      phoneType = it.type,
+      phoneNumber = it.number,
+      extNumber = it.extension,
+      createdBy = it.createUsername ?: "MIGRATION",
+      createdTime = it.createDateTime ?: LocalDateTime.now(),
+      updatedBy = it.modifyUsername,
+      updatedTime = it.modifyDateTime,
+    ),
+  )
+
+  private fun createOrganisationEmail(
+    organisation: OrganisationWithFixedIdEntity,
+    it: MigrateOrganisationEmailAddress,
+  ) = organisationEmailRepository.saveAndFlush(
+    OrganisationEmailEntity(
+      organisationEmailId = 0,
+      organisationId = organisation.id(),
+      emailAddress = it.email,
+      createdBy = it.createUsername ?: "MIGRATION",
+      createdTime = it.createDateTime ?: LocalDateTime.now(),
+      updatedBy = it.modifyUsername,
+      updatedTime = it.modifyDateTime,
+    ),
+  )
+
+  private fun createOrganisationWebAddress(
+    organisation: OrganisationWithFixedIdEntity,
+    it: MigrateOrganisationWebAddress,
+  ) = organisationWebAddressRepository.saveAndFlush(
+    OrganisationWebAddressEntity(
+      organisationWebAddressId = 0,
+      organisationId = organisation.id(),
+      webAddress = it.webAddress,
+      createdBy = it.createUsername ?: "MIGRATION",
+      createdTime = it.createDateTime ?: LocalDateTime.now(),
+      updatedBy = it.modifyUsername,
+      updatedTime = it.modifyDateTime,
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/helper/TestAPIClient.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePhoneRe
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdatePrisonerContactRestrictionRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.UpdateRelationshipRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateContactRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationRequest
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressPhoneDetails
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactAddressResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ContactCreationResult
@@ -40,6 +41,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerCont
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.PrisonerContactSummary
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateContactResponse
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateOrganisationResponse
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 import java.net.URI
@@ -374,6 +376,20 @@ class TestAPIClient(private val webTestClient: WebTestClient, private val jwtAut
       .isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBody(MigrateContactResponse::class.java)
+      .returnResult().responseBody!!
+
+  fun migrateAnOrganisation(request: MigrateOrganisationRequest, authRole: String = "ROLE_CONTACTS_MIGRATION") =
+    webTestClient.post()
+      .uri("/migrate/organisation")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(authRole)))
+      .bodyValue(request)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(MigrateOrganisationResponse::class.java)
       .returnResult().responseBody!!
 
   fun getContactGlobalRestrictions(contactId: Long, role: String = "ROLE_CONTACTS_ADMIN"): List<ContactRestrictionDetails> = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigrateOrganisationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigrateOrganisationIntegrationTest.kt
@@ -1,0 +1,517 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.resource.migrate
+
+import org.apache.commons.lang3.RandomUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationEmailAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationPhoneNumber
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationRequest
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationWebAddress
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.ElementType
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationEmailRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationPhoneRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationTypeRepository
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationWebAddressRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class MigrateOrganisationIntegrationTest : PostgresIntegrationTestBase() {
+
+  private val corporateId: Long = RandomUtils.secure().randomLong(1, 10000)
+
+  @Autowired
+  private lateinit var organisationRepository: OrganisationRepository
+
+  @Autowired
+  private lateinit var organisationTypeRepository: OrganisationTypeRepository
+
+  @Autowired
+  private lateinit var organisationPhoneRepository: OrganisationPhoneRepository
+
+  @Autowired
+  private lateinit var organisationEmailRepository: OrganisationEmailRepository
+
+  @Autowired
+  private lateinit var organisationWebAddressRepository: OrganisationWebAddressRepository
+
+  @Autowired
+  private lateinit var organisationAddressRepository: OrganisationAddressRepository
+
+  @Autowired
+  private lateinit var organisationAddressPhoneRepository: OrganisationAddressPhoneRepository
+
+  @Test
+  fun `should return unauthorized if no token provided`() {
+    webTestClient.post()
+      .uri("/migrate/organisation")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(minimalMigrationRequest())
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["ROLE_CONTACTS_ADMIN", "ROLE_CONTACTS__R", "ROLE_CONTACTS__RW"])
+  fun `should return forbidden without an authorised role on the token`(authRole: String) {
+    webTestClient.post()
+      .uri("/migrate/organisation")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(minimalMigrationRequest())
+      .headers(setAuthorisation(roles = listOf(authRole)))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `can migrate a minimal organisation`() {
+    val request = minimalMigrationRequest()
+    val countOrgsBefore = organisationRepository.count()
+
+    val result = testAPIClient.migrateAnOrganisation(request)
+
+    with(result.organisation) {
+      assertThat(elementType).isEqualTo(ElementType.ORGANISATION)
+      // NOTE: The DPS and NOMIS ids should both be the same
+      assertThat(nomisId).isEqualTo(request.nomisCorporateId)
+      assertThat(dpsId).isEqualTo(request.nomisCorporateId)
+    }
+
+    assertThat(organisationRepository.count()).isEqualTo(countOrgsBefore + 1)
+  }
+
+  @Test
+  fun `can migrate an organisation with all top level details`() {
+    val request = MigrateOrganisationRequest(
+      nomisCorporateId = corporateId,
+      organisationName = "Basic Org",
+      programmeNumber = "P1",
+      vatNumber = "VAT",
+      caseloadId = "CAS",
+      comments = "Comments",
+      active = false,
+      deactivatedDate = LocalDate.of(2020, 2, 3),
+      organisationTypes = emptyList(),
+      phoneNumbers = emptyList(),
+      emailAddresses = emptyList(),
+      webAddresses = emptyList(),
+      addresses = emptyList(),
+    ).apply {
+      createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+      createUsername = "CREATED"
+      modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+      modifyUsername = "MODIFIED"
+    }
+
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    with(organisationRepository.getReferenceById(corporateId)) {
+      assertThat(organisationName).isEqualTo("Basic Org")
+      assertThat(programmeNumber).isEqualTo("P1")
+      assertThat(vatNumber).isEqualTo("VAT")
+      assertThat(caseloadId).isEqualTo("CAS")
+      assertThat(comments).isEqualTo("Comments")
+      assertThat(active).isEqualTo(false)
+      assertThat(deactivatedDate).isEqualTo(LocalDate.of(2020, 2, 3))
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+      assertThat(updatedBy).isEqualTo("MODIFIED")
+    }
+  }
+
+  @Test
+  fun `can migrate an organisation with organisation types`() {
+    val request = minimalMigrationRequest().copy(
+      organisationTypes = listOf(
+        MigrateOrganisationType("BSKILLS").apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+          modifyUsername = "MODIFIED"
+        },
+        MigrateOrganisationType("TRUST").apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+          modifyUsername = "MODIFIED"
+        },
+      ),
+    )
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    assertThat(migrated.organisationTypes).hasSize(2)
+    migrated.organisationTypes.onEach {
+      with(organisationTypeRepository.getReferenceById(it.dpsId)) {
+        assertThat(organisationType).isEqualTo(it.organisationType)
+        assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+        assertThat(createdBy).isEqualTo("CREATED")
+        assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+        assertThat(updatedBy).isEqualTo("MODIFIED")
+      }
+    }
+  }
+
+  @Test
+  fun `can migrate an organisation with phone numbers`() {
+    val request = minimalMigrationRequest().copy(
+      phoneNumbers = listOf(
+        MigrateOrganisationPhoneNumber(
+          nomisPhoneId = 999,
+          type = "MOB",
+          number = "123",
+          extension = null,
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = null
+          modifyUsername = null
+        },
+        MigrateOrganisationPhoneNumber(
+          nomisPhoneId = 888,
+          type = "HOME",
+          number = "456",
+          extension = "789",
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+          modifyUsername = "MODIFIED"
+        },
+      ),
+    )
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    assertThat(migrated.phoneNumbers).hasSize(2)
+
+    with(organisationPhoneRepository.getReferenceById(migrated.phoneNumbers.find { it.nomisId == 999L }!!.dpsId)) {
+      assertThat(phoneType).isEqualTo("MOB")
+      assertThat(phoneNumber).isEqualTo("123")
+      assertThat(extNumber).isNull()
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isNull()
+      assertThat(updatedBy).isNull()
+    }
+    with(organisationPhoneRepository.getReferenceById(migrated.phoneNumbers.find { it.nomisId == 888L }!!.dpsId)) {
+      assertThat(phoneType).isEqualTo("HOME")
+      assertThat(phoneNumber).isEqualTo("456")
+      assertThat(extNumber).isEqualTo("789")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+      assertThat(updatedBy).isEqualTo("MODIFIED")
+    }
+  }
+
+  @Test
+  fun `can migrate an organisation with email addresses`() {
+    val request = minimalMigrationRequest().copy(
+      emailAddresses = listOf(
+        MigrateOrganisationEmailAddress(
+          nomisEmailAddressId = 999,
+          email = "test@example.com",
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = null
+          modifyUsername = null
+        },
+        MigrateOrganisationEmailAddress(
+          nomisEmailAddressId = 888,
+          email = "another@example.com",
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+          modifyUsername = "MODIFIED"
+        },
+      ),
+    )
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    assertThat(migrated.emailAddresses).hasSize(2)
+
+    with(organisationEmailRepository.getReferenceById(migrated.emailAddresses.find { it.nomisId == 999L }!!.dpsId)) {
+      assertThat(emailAddress).isEqualTo("test@example.com")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isNull()
+      assertThat(updatedBy).isNull()
+    }
+    with(organisationEmailRepository.getReferenceById(migrated.emailAddresses.find { it.nomisId == 888L }!!.dpsId)) {
+      assertThat(emailAddress).isEqualTo("another@example.com")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+      assertThat(updatedBy).isEqualTo("MODIFIED")
+    }
+  }
+
+  @Test
+  fun `can migrate an organisation with web addresses`() {
+    val request = minimalMigrationRequest().copy(
+      webAddresses = listOf(
+        MigrateOrganisationWebAddress(
+          nomisWebAddressId = 999,
+          webAddress = "test@example.com",
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = null
+          modifyUsername = null
+        },
+        MigrateOrganisationWebAddress(
+          nomisWebAddressId = 888,
+          webAddress = "another@example.com",
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+          modifyUsername = "MODIFIED"
+        },
+      ),
+    )
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    assertThat(migrated.webAddresses).hasSize(2)
+
+    with(organisationWebAddressRepository.getReferenceById(migrated.webAddresses.find { it.nomisId == 999L }!!.dpsId)) {
+      assertThat(webAddress).isEqualTo("test@example.com")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isNull()
+      assertThat(updatedBy).isNull()
+    }
+    with(organisationWebAddressRepository.getReferenceById(migrated.webAddresses.find { it.nomisId == 888L }!!.dpsId)) {
+      assertThat(webAddress).isEqualTo("another@example.com")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+      assertThat(updatedBy).isEqualTo("MODIFIED")
+    }
+  }
+
+  @Test
+  fun `can migrate an organisation with addresses`() {
+    val request = minimalMigrationRequest().copy(
+      addresses = listOf(
+        MigrateOrganisationAddress(
+          nomisAddressId = 999,
+          type = null,
+          primaryAddress = false,
+          mailAddress = false,
+          serviceAddress = false,
+          noFixedAddress = false,
+          flat = null,
+          premise = null,
+          street = null,
+          locality = null,
+          city = null,
+          county = null,
+          postCode = null,
+          country = null,
+          specialNeedsCode = null,
+          contactPersonName = null,
+          businessHours = null,
+          comment = null,
+          startDate = null,
+          endDate = null,
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = null
+          modifyUsername = null
+        },
+        MigrateOrganisationAddress(
+          nomisAddressId = 888,
+          type = "HOME",
+          primaryAddress = true,
+          mailAddress = true,
+          serviceAddress = true,
+          noFixedAddress = true,
+          flat = "F1",
+          premise = "P1",
+          street = "S1",
+          locality = "A1",
+          city = "25343",
+          county = "S.YORKSHIRE",
+          postCode = "P1C1",
+          country = "ENG",
+          specialNeedsCode = "DEAF",
+          contactPersonName = "CP1",
+          businessHours = "BH1",
+          comment = "Comments",
+        ).apply {
+          createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+          createUsername = "CREATED"
+          modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+          modifyUsername = "MODIFIED"
+        },
+      ),
+    )
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    assertThat(migrated.addresses).hasSize(2)
+
+    with(organisationAddressRepository.getReferenceById(migrated.addresses.find { it.address.nomisId == 999L }!!.address.dpsId)) {
+      assertThat(addressType).isNull()
+      assertThat(primaryAddress).isFalse()
+      assertThat(mailAddress).isFalse()
+      assertThat(serviceAddress).isFalse()
+      assertThat(noFixedAddress).isFalse()
+      assertThat(flat).isNull()
+      assertThat(property).isNull()
+      assertThat(street).isNull()
+      assertThat(area).isNull()
+      assertThat(cityCode).isNull()
+      assertThat(countyCode).isNull()
+      assertThat(postCode).isNull()
+      assertThat(countryCode).isNull()
+      assertThat(specialNeedsCode).isNull()
+      assertThat(contactPersonName).isNull()
+      assertThat(businessHours).isNull()
+      assertThat(comments).isNull()
+      assertThat(startDate).isNull()
+      assertThat(endDate).isNull()
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isNull()
+      assertThat(updatedBy).isNull()
+    }
+    with(organisationAddressRepository.getReferenceById(migrated.addresses.find { it.address.nomisId == 888L }!!.address.dpsId)) {
+      assertThat(addressType).isEqualTo("HOME")
+      assertThat(primaryAddress).isTrue()
+      assertThat(mailAddress).isTrue()
+      assertThat(serviceAddress).isTrue()
+      assertThat(noFixedAddress).isTrue()
+      assertThat(flat).isEqualTo("F1")
+      assertThat(property).isEqualTo("P1")
+      assertThat(street).isEqualTo("S1")
+      assertThat(area).isEqualTo("A1")
+      assertThat(cityCode).isEqualTo("25343")
+      assertThat(countyCode).isEqualTo("S.YORKSHIRE")
+      assertThat(postCode).isEqualTo("P1C1")
+      assertThat(countryCode).isEqualTo("ENG")
+      assertThat(specialNeedsCode).isEqualTo("DEAF")
+      assertThat(contactPersonName).isEqualTo("CP1")
+      assertThat(businessHours).isEqualTo("BH1")
+      assertThat(comments).isEqualTo("Comments")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+      assertThat(updatedBy).isEqualTo("MODIFIED")
+    }
+  }
+
+  @Test
+  fun `can migrate an organisation with address phone numbers`() {
+    val request = minimalMigrationRequest().copy(
+      addresses = listOf(
+        MigrateOrganisationAddress(
+          nomisAddressId = 999,
+          type = null,
+          primaryAddress = false,
+          mailAddress = false,
+          serviceAddress = false,
+          noFixedAddress = false,
+          flat = null,
+          premise = null,
+          street = null,
+          locality = null,
+          city = null,
+          county = null,
+          postCode = null,
+          country = null,
+          specialNeedsCode = null,
+          contactPersonName = null,
+          businessHours = null,
+          comment = null,
+          startDate = null,
+          endDate = null,
+          phoneNumbers = listOf(
+            MigrateOrganisationPhoneNumber(
+              nomisPhoneId = 123,
+              type = "MOB",
+              number = "123",
+              extension = null,
+            ).apply {
+              createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+              createUsername = "CREATED"
+              modifyDateTime = null
+              modifyUsername = null
+            },
+            MigrateOrganisationPhoneNumber(
+              nomisPhoneId = 456,
+              type = "HOME",
+              number = "456",
+              extension = "789",
+            ).apply {
+              createDateTime = LocalDateTime.of(2020, 2, 3, 10, 30)
+              createUsername = "CREATED"
+              modifyDateTime = LocalDateTime.of(2020, 3, 4, 11, 45)
+              modifyUsername = "MODIFIED"
+            },
+          ),
+        ),
+      ),
+    )
+    val migrated = testAPIClient.migrateAnOrganisation(request)
+    assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
+    assertThat(migrated.addresses).hasSize(1)
+    val migratedAddress = migrated.addresses.first()
+
+    val firstPhone = organisationAddressPhoneRepository.getReferenceById(migratedAddress.phoneNumbers.find { it.nomisId == 123L }!!.dpsId)
+    assertThat(firstPhone.organisationAddressId).isEqualTo(migratedAddress.address.dpsId)
+    val secondPhone = organisationAddressPhoneRepository.getReferenceById(migratedAddress.phoneNumbers.find { it.nomisId == 456L }!!.dpsId)
+    assertThat(secondPhone.organisationAddressId).isEqualTo(migratedAddress.address.dpsId)
+
+    with(organisationPhoneRepository.getReferenceById(firstPhone.organisationPhoneId)) {
+      assertThat(phoneType).isEqualTo("MOB")
+      assertThat(phoneNumber).isEqualTo("123")
+      assertThat(extNumber).isNull()
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isNull()
+      assertThat(updatedBy).isNull()
+    }
+    with(organisationPhoneRepository.getReferenceById(secondPhone.organisationPhoneId)) {
+      assertThat(phoneType).isEqualTo("HOME")
+      assertThat(phoneNumber).isEqualTo("456")
+      assertThat(extNumber).isEqualTo("789")
+      assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
+      assertThat(createdBy).isEqualTo("CREATED")
+      assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
+      assertThat(updatedBy).isEqualTo("MODIFIED")
+    }
+  }
+
+  private fun minimalMigrationRequest(): MigrateOrganisationRequest = MigrateOrganisationRequest(
+    nomisCorporateId = corporateId,
+    organisationName = "Basic Org",
+    programmeNumber = null,
+    vatNumber = null,
+    caseloadId = null,
+    comments = null,
+    active = true,
+    deactivatedDate = null,
+    organisationTypes = emptyList(),
+    phoneNumbers = emptyList(),
+    emailAddresses = emptyList(),
+    webAddresses = emptyList(),
+    addresses = emptyList(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/ContactMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/ContactMigrationServiceTest.kt
@@ -47,7 +47,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.PrisonerContactR
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-class MigrationServiceTest {
+class ContactMigrationServiceTest {
   private val contactRepository: ContactWithFixedIdRepository = mock()
   private val contactAddressRepository: ContactAddressRepository = mock()
   private val contactAddressPhoneRepository: ContactAddressPhoneRepository = mock()
@@ -59,7 +59,7 @@ class MigrationServiceTest {
   private val prisonerContactRestrictionRepository: PrisonerContactRestrictionRepository = mock()
   private val contactEmploymentRepository: ContactEmploymentRepository = mock()
 
-  val migrationService = MigrationService(
+  val migrationService = ContactMigrationService(
     contactRepository,
     contactAddressRepository,
     contactAddressPhoneRepository,


### PR DESCRIPTION
Allow creation of an organisation using the NOMIS corporate id as the PK.

Allows for creation of all associated entities with it.

Currently does not handle duplicate migrations.

Remove use of @CreationTimestamp on organisation entities as this did not allow for overriding of the timestamp with one from NOMIS.