### PR TITLE
PRC-406: Handle duplicate organisations on migrate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateOrganisationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateOrganisationRequest.kt
@@ -45,7 +45,7 @@ data class MigrateOrganisationRequest(
   @Schema(description = "The date the organisation was deactivated, EXPIRY_DATE in NOMIS", example = "2010-12-30")
   val deactivatedDate: LocalDate?,
 
-  @Schema(description = "The types of the organisation, CORPORATE_TYPES in NOMIS.", example = "TRUST")
+  @Schema(description = "The types of the organisation, CORPORATE_TYPES in NOMIS.")
   val organisationTypes: List<MigrateOrganisationType>,
 
   @Schema(description = "Phone numbers associated directly with the organisation and it's addresses")
@@ -62,7 +62,7 @@ data class MigrateOrganisationRequest(
 ) : AbstractAuditable()
 
 data class MigrateOrganisationType(
-  @Schema(description = "Type of organisation from reference data")
+  @Schema(description = "Type of organisation from reference data", example = "TRUST")
   val type: String,
 ) : AbstractAuditable()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/EmploymentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/EmploymentRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
 
 @Repository
-interface EmploymentRepository : JpaRepository<EmploymentEntity, Long>
+interface EmploymentRepository : JpaRepository<EmploymentEntity, Long> {
+  @Modifying
+  @Query("delete from EmploymentEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressPhoneRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressPhoneEntity
 
 @Repository
-interface OrganisationAddressPhoneRepository : JpaRepository<OrganisationAddressPhoneEntity, Long>
+interface OrganisationAddressPhoneRepository : JpaRepository<OrganisationAddressPhoneEntity, Long> {
+  @Modifying
+  @Query("delete from OrganisationAddressPhoneEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressEntity
 
 @Repository
-interface OrganisationAddressRepository : JpaRepository<OrganisationAddressEntity, Long>
+interface OrganisationAddressRepository : JpaRepository<OrganisationAddressEntity, Long> {
+  @Modifying
+  @Query("delete from OrganisationAddressEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationEmailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationEmailRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEntity
 
 @Repository
-interface OrganisationEmailRepository : JpaRepository<OrganisationEmailEntity, Long>
+interface OrganisationEmailRepository : JpaRepository<OrganisationEmailEntity, Long> {
+  @Modifying
+  @Query("delete from OrganisationEmailEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationPhoneRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEntity
 
 @Repository
-interface OrganisationPhoneRepository : JpaRepository<OrganisationPhoneEntity, Long>
+interface OrganisationPhoneRepository : JpaRepository<OrganisationPhoneEntity, Long> {
+  @Modifying
+  @Query("delete from OrganisationPhoneEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
 
 @Repository
-interface OrganisationTypeRepository : JpaRepository<OrganisationTypeEntity, Long>
+interface OrganisationTypeRepository : JpaRepository<OrganisationTypeEntity, Long> {
+  @Modifying
+  @Query("delete from OrganisationTypeEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWebAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWebAddressRepository.kt
@@ -1,8 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddressEntity
 
 @Repository
-interface OrganisationWebAddressRepository : JpaRepository<OrganisationWebAddressEntity, Long>
+interface OrganisationWebAddressRepository : JpaRepository<OrganisationWebAddressEntity, Long> {
+  @Modifying
+  @Query("delete from OrganisationWebAddressEntity c where c.organisationId = :organisationId")
+  fun deleteAllByOrganisationId(organisationId: Long): Int
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/OrganisationMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/OrganisationMigrationService.kt
@@ -55,6 +55,11 @@ class OrganisationMigrationService(
       request.organisationTypes.size,
     )
 
+    if (organisationRepository.existsById(request.nomisCorporateId)) {
+      logger.info("Migration: Duplicate corporate ID received ${request.nomisCorporateId} - replacing it")
+      removeExistingOrgAndDetail(request.nomisCorporateId)
+    }
+
     val organisation = createOrganisation(request)
     val createdOrganisation = IdPair(
       ElementType.ORGANISATION,
@@ -143,6 +148,16 @@ class OrganisationMigrationService(
       createdWebAddresses,
       createdAddresses,
     )
+  }
+
+  private fun removeExistingOrgAndDetail(organisationId: Long) {
+    organisationAddressPhoneRepository.deleteAllByOrganisationId(organisationId)
+    organisationAddressRepository.deleteAllByOrganisationId(organisationId)
+    organisationPhoneRepository.deleteAllByOrganisationId(organisationId)
+    organisationEmailRepository.deleteAllByOrganisationId(organisationId)
+    organisationWebAddressRepository.deleteAllByOrganisationId(organisationId)
+    organisationTypeRepository.deleteAllByOrganisationId(organisationId)
+    organisationRepository.deleteById(organisationId)
   }
 
   private fun createOrganisationAddressPhone(


### PR DESCRIPTION
When a migration is run the client might time out or fail while the organisation is actually created. To allow for replays we must remove the existing organisation and any associated entities and then re-create them.

Also minor swagger doc fix.