### PR TITLE
PRC-419: Use org id and type as pk

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeEntity.kt
@@ -1,23 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
 
 import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "organisation_type")
 data class OrganisationTypeEntity(
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val organisationTypeId: Long,
-
-  val organisationId: Long,
-
-  val organisationType: String,
+  @EmbeddedId
+  val id: OrganisationTypeId,
 
   @Column(updatable = false)
   val createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/entity/OrganisationTypeId.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppscontactsapi.entity
+
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+
+@Embeddable
+data class OrganisationTypeId(val organisationId: Long, val organisationType: String) : Serializable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/MigrateOrganisationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/migrate/MigrateOrganisationResponse.kt
@@ -7,8 +7,8 @@ data class MigrateOrganisationResponse(
   @Schema(description = "The pair of IDs for this organisation in NOMIS")
   val organisation: IdPair,
 
-  @Schema(description = "List of NOMIS and DPS IDs for organisation types.")
-  val organisationTypes: List<MigratedOrganisationType> = emptyList(),
+  @Schema(description = "List of organisation types that were created")
+  val organisationTypes: List<String> = emptyList(),
 
   @Schema(description = "List of Nomis and DPS IDs for phone numbers")
   val phoneNumbers: List<IdPair> = emptyList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeId
 
 @Repository
-interface OrganisationTypeRepository : JpaRepository<OrganisationTypeEntity, Long> {
+interface OrganisationTypeRepository : JpaRepository<OrganisationTypeEntity, OrganisationTypeId> {
   @Modifying
-  @Query("delete from OrganisationTypeEntity c where c.organisationId = :organisationId")
+  @Query("delete from OrganisationTypeEntity c where c.id.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
+
+  fun getByIdOrganisationId(organisationId: Long): List<OrganisationTypeEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/OrganisationMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/migrate/OrganisationMigrationService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressP
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeId
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddressEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWithFixedIdEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.request.migrate.MigrateOrganisationEmailAddress
@@ -19,7 +20,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.Elem
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.IdPair
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigrateOrganisationResponse
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigratedOrganisationAddress
-import uk.gov.justice.digital.hmpps.hmppscontactsapi.model.response.migrate.MigratedOrganisationType
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressPhoneRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationAddressRepository
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.repository.OrganisationEmailRepository
@@ -67,10 +67,7 @@ class OrganisationMigrationService(
       organisation.organisationId,
     )
     val createdOrganisationTypes = request.organisationTypes.map {
-      MigratedOrganisationType(
-        it.type,
-        createOrganisationType(organisation, it).organisationTypeId,
-      )
+      createOrganisationType(organisation, it).id.organisationType
     }
     val createdPhoneNumbers = request.phoneNumbers.map {
       IdPair(
@@ -201,9 +198,10 @@ class OrganisationMigrationService(
     it: MigrateOrganisationType,
   ) = organisationTypeRepository.saveAndFlush(
     OrganisationTypeEntity(
-      organisationTypeId = 0,
-      organisationId = organisation.id(),
-      organisationType = it.type,
+      OrganisationTypeId(
+        organisationId = organisation.id(),
+        organisationType = it.type,
+      ),
       createdBy = it.createUsername ?: "MIGRATION",
       createdTime = it.createDateTime ?: LocalDateTime.now(),
       updatedBy = it.modifyUsername,

--- a/src/main/resources/migrations/common/V2025.01.21.12__change_pk_on_org_types.sql
+++ b/src/main/resources/migrations/common/V2025.01.21.12__change_pk_on_org_types.sql
@@ -1,0 +1,8 @@
+--
+-- Changing primary key to just be organisation_id and organisation_type
+--
+ALTER TABLE organisation_type DROP CONSTRAINT organisation_type_pkey;
+ALTER TABLE organisation_type DROP COLUMN organisation_type_id;
+ALTER TABLE organisation_type ADD CONSTRAINT organisation_type_pkey PRIMARY KEY (organisation_id, organisation_type);
+
+-- End

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/OrganisationEntityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/db/OrganisationEntityIntegrationTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEnt
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeEntity
+import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeId
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddressEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWithFixedIdEntity
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.integration.PostgresIntegrationTestBase
@@ -141,27 +142,28 @@ class OrganisationEntityIntegrationTest : PostgresIntegrationTestBase() {
   fun `can create organisation types`() {
     val org = aNewOrganisation()
     val withMinimalFields = OrganisationTypeEntity(
-      organisationTypeId = 0,
-      organisationId = org.id(),
-      organisationType = "SWO",
+      OrganisationTypeId(
+        organisationId = org.id(),
+        organisationType = "SWO",
+      ),
       createdBy = "CREATED",
       createdTime = LocalDateTime.now().minusMinutes(20),
       updatedBy = null,
       updatedTime = null,
     )
     val withAllFields = OrganisationTypeEntity(
-      organisationTypeId = 0,
-      organisationId = org.id(),
-      organisationType = "SWO",
+      OrganisationTypeId(
+        organisationId = org.id(),
+        organisationType = "TRUST",
+      ),
       createdBy = "CREATED",
       createdTime = LocalDateTime.now().minusMinutes(20),
       updatedBy = "UPDATED",
       updatedTime = LocalDateTime.now().plusMinutes(20),
     )
-    val createdMin = organisationTypeRepository.saveAndFlush(withMinimalFields)
-    assertThat(createdMin.organisationTypeId).isGreaterThan(0)
-    val createdMax = organisationTypeRepository.saveAndFlush(withAllFields)
-    assertThat(createdMax.organisationTypeId).isGreaterThan(0)
+    organisationTypeRepository.saveAndFlush(withMinimalFields)
+    organisationTypeRepository.saveAndFlush(withAllFields)
+    assertThat(organisationTypeRepository.getByIdOrganisationId(org.id())).hasSize(2)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/OrganisationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/OrganisationIntegrationTest.kt
@@ -70,7 +70,7 @@ class OrganisationIntegrationTest : PostgresIntegrationTestBase() {
         .isCreated
         .expectBody(Organisation::class.java)
         .returnResult()
-        .responseBody
+        .responseBody!!
 
       val organisation = testAPIClient.getOrganisation(response.organisationId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigrateOrganisationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/migrate/MigrateOrganisationIntegrationTest.kt
@@ -153,16 +153,7 @@ class MigrateOrganisationIntegrationTest : PostgresIntegrationTestBase() {
     )
     val migrated = testAPIClient.migrateAnOrganisation(request)
     assertThat(migrated.organisation.dpsId).isEqualTo(corporateId)
-    assertThat(migrated.organisationTypes).hasSize(2)
-    migrated.organisationTypes.onEach {
-      with(organisationTypeRepository.getReferenceById(it.dpsId)) {
-        assertThat(organisationType).isEqualTo(it.organisationType)
-        assertThat(createdTime).isEqualTo(LocalDateTime.of(2020, 2, 3, 10, 30))
-        assertThat(createdBy).isEqualTo("CREATED")
-        assertThat(updatedTime).isEqualTo(LocalDateTime.of(2020, 3, 4, 11, 45))
-        assertThat(updatedBy).isEqualTo("MODIFIED")
-      }
-    }
+    assertThat(migrated.organisationTypes).isEqualTo(listOf("BSKILLS", "TRUST"))
   }
 
   @Test


### PR DESCRIPTION
Change organisation_type to use organisation_id and organisation_type as the primary key instead of a surrogate key. This ensures no duplicates and removes the need to track ids for sync