### PR TITLE
PRC-422: Fixup ref data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/migrate/MigrateContactRequest.kt
@@ -225,7 +225,7 @@ data class MigrateRelationship(
     """
     Coded value indicating either a social or official contact (mandatory).
     This is a coded value (from the group code CONTACT_TYPE in reference data).
-    Known values are (S) Social/Family or (O) official.
+    Known values are (S) Social or (O) official.
     """,
     example = "S",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncCreatePrisonerContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncCreatePrisonerContactRequest.kt
@@ -18,7 +18,7 @@ data class SyncCreatePrisonerContactRequest(
     """
       Coded value indicating either a social or official contact (mandatory).
       This is a coded value (from the group code CONTACT_TYPE in reference data).
-      Known values are (S) Social/Family or (O) official.
+      Known values are (S) Social or (O) official.
       """,
     example = "S",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncUpdatePrisonerContactRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/request/sync/SyncUpdatePrisonerContactRequest.kt
@@ -18,7 +18,7 @@ data class SyncUpdatePrisonerContactRequest(
     """
       Coded value indicating either a social or official contact (mandatory).
       This is a coded value from the group code CONTACT_TYPE in reference data.
-      Known values are (S) Social/Family or (O) official.
+      Known values are (S) Social or (O) official.
       """,
     example = "S",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/LinkedPrisonerRelationshipDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/LinkedPrisonerRelationshipDetails.kt
@@ -12,13 +12,13 @@ data class LinkedPrisonerRelationshipDetails(
     """
       Coded value indicating either a social or official contact (mandatory).
       This is a coded value from the group code CONTACT_TYPE in reference data.
-      Known values are (S) Social/Family or (O) official.
+      Known values are (S) Social or (O) official.
       """,
     example = "S",
   )
   val relationshipType: String,
 
-  @Schema(description = "The description of the contact relationship type. Description from reference data Official or Social/Family", example = "Official")
+  @Schema(description = "The description of the contact relationship type. Description from reference data Official or Social", example = "Official")
   val relationshipTypeDescription: String,
 
   @Schema(description = "The relationship to the prisoner. A code from SOCIAL_RELATIONSHIP or OFFICIAL_RELATIONSHIP reference data groups depending on the relationship type.", example = "FRI")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactRelationshipDetails.kt
@@ -18,13 +18,13 @@ data class PrisonerContactRelationshipDetails(
     """
       Coded value indicating either a social or official contact (mandatory).
       This is a coded value from the group code CONTACT_TYPE in reference data.
-      Known values are (S) Social/Family or (O) official.
+      Known values are (S) Social or (O) official.
       """,
     example = "S",
   )
   val relationshipType: String,
 
-  @Schema(description = "The description of the contact relationship type. Description from reference data Official or Social/Family", example = "Official")
+  @Schema(description = "The description of the contact relationship type. Description from reference data Official or Social", example = "Official")
   val relationshipTypeDescription: String,
 
   @Schema(description = "The relationship to the prisoner. A code from SOCIAL_RELATIONSHIP or OFFICIAL_RELATIONSHIP reference data groups depending on the relationship type.", example = "FRI")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/PrisonerContactSummary.kt
@@ -32,7 +32,7 @@ data class PrisonerContactSummary(
     """
       Coded value indicating either a social or official contact (mandatory).
       This is a coded value from the group code CONTACT_TYPE in reference data.
-      Known values are (S) Social/Family or (O) official.
+      Known values are (S) Social or (O) official.
       """,
     example = "S",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncPrisonerContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/model/response/sync/SyncPrisonerContact.kt
@@ -21,7 +21,7 @@ data class SyncPrisonerContact(
     """
       Coded value indicating either a social or official contact (mandatory).
       This is a coded value (from the group code CONTACT_TYPE in reference data).
-      Known values are (S) Social/Family or (O) official.
+      Known values are (S) Social or (O) official.
       """,
     example = "S",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/EmploymentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/EmploymentRepository.kt
@@ -9,6 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.EmploymentEntity
 @Repository
 interface EmploymentRepository : JpaRepository<EmploymentEntity, Long> {
   @Modifying
-  @Query("delete from EmploymentEntity cr where cr.contactId = :contactId")
+  @Query("delete from EmploymentEntity e where e.contactId = :contactId")
   fun deleteAllByContactId(contactId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressPhoneRepository.kt
@@ -9,6 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressP
 @Repository
 interface OrganisationAddressPhoneRepository : JpaRepository<OrganisationAddressPhoneEntity, Long> {
   @Modifying
-  @Query("delete from OrganisationAddressPhoneEntity c where c.organisationId = :organisationId")
+  @Query("delete from OrganisationAddressPhoneEntity o where o.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationAddressRepository.kt
@@ -9,6 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationAddressE
 @Repository
 interface OrganisationAddressRepository : JpaRepository<OrganisationAddressEntity, Long> {
   @Modifying
-  @Query("delete from OrganisationAddressEntity c where c.organisationId = :organisationId")
+  @Query("delete from OrganisationAddressEntity o where o.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationEmailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationEmailRepository.kt
@@ -9,6 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationEmailEnt
 @Repository
 interface OrganisationEmailRepository : JpaRepository<OrganisationEmailEntity, Long> {
   @Modifying
-  @Query("delete from OrganisationEmailEntity c where c.organisationId = :organisationId")
+  @Query("delete from OrganisationEmailEntity o where o.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationPhoneRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationPhoneRepository.kt
@@ -9,6 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationPhoneEnt
 @Repository
 interface OrganisationPhoneRepository : JpaRepository<OrganisationPhoneEntity, Long> {
   @Modifying
-  @Query("delete from OrganisationPhoneEntity c where c.organisationId = :organisationId")
+  @Query("delete from OrganisationPhoneEntity o where o.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationTypeRepository.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationTypeId
 @Repository
 interface OrganisationTypeRepository : JpaRepository<OrganisationTypeEntity, OrganisationTypeId> {
   @Modifying
-  @Query("delete from OrganisationTypeEntity c where c.id.organisationId = :organisationId")
+  @Query("delete from OrganisationTypeEntity o where o.id.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
 
   fun getByIdOrganisationId(organisationId: Long): List<OrganisationTypeEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWebAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/repository/OrganisationWebAddressRepository.kt
@@ -9,6 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.entity.OrganisationWebAddre
 @Repository
 interface OrganisationWebAddressRepository : JpaRepository<OrganisationWebAddressEntity, Long> {
   @Modifying
-  @Query("delete from OrganisationWebAddressEntity c where c.organisationId = :organisationId")
+  @Query("delete from OrganisationWebAddressEntity o where o.organisationId = :organisationId")
   fun deleteAllByOrganisationId(organisationId: Long): Int
 }

--- a/src/main/resources/migrations/common/V2025.01.21.13__reference_data_updates.sql
+++ b/src/main/resources/migrations/common/V2025.01.21.13__reference_data_updates.sql
@@ -1,0 +1,15 @@
+--
+-- Some small updates to reference data descriptions
+--
+
+-- Change from Social/Family to Social
+UPDATE reference_codes SET description = 'Social' WHERE group_code = 'RELATIONSHIP_TYPE' AND code = 'S';
+
+-- Change mixed case entries to start upper case only
+UPDATE reference_codes SET description = 'Access requirements' WHERE group_code = 'RESTRICTION' and code = 'ACC';
+UPDATE reference_codes SET description = 'Child visitors to be vetted' WHERE group_code = 'RESTRICTION' and code = 'CHILD';
+UPDATE reference_codes SET description = 'Disability health concerns' WHERE group_code = 'RESTRICTION' and code = 'DIHCON';
+UPDATE reference_codes SET description = 'Non-contact visit' WHERE group_code = 'RESTRICTION' and code = 'NONCON';
+UPDATE reference_codes SET description = 'Previous info' WHERE group_code = 'RESTRICTION' and code = 'PREINF';
+
+-- End

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/helpers/Examples.kt
@@ -288,7 +288,7 @@ fun createPrisonerContactRelationshipDetails(
   contactId: Long = 99,
   prisonerNumber: String = "A1234BC",
   relationshipType: String = "S",
-  relationshipTypeDescription: String = "Social/Family",
+  relationshipTypeDescription: String = "Social",
   relationshipCode: String = "FRI",
   relationshipDescription: String = "Friend",
   emergencyContact: Boolean = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetContactLinkedPrisonerIntegrationTest.kt
@@ -97,7 +97,7 @@ class GetContactLinkedPrisonerIntegrationTest : PostgresIntegrationTestBase() {
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = prisoner2FatherRelationship.prisonerContactId,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "FA",
               relationshipToPrisonerDescription = "Father",
             ),
@@ -112,14 +112,14 @@ class GetContactLinkedPrisonerIntegrationTest : PostgresIntegrationTestBase() {
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = prisoner1OtherRelationship.prisonerContactId,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "OTHER",
               relationshipToPrisonerDescription = "Other - Social",
             ),
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = prisoner1FriendRelationship.prisonerContactId,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "FRI",
               relationshipToPrisonerDescription = "Friend",
             ),
@@ -151,7 +151,7 @@ class GetContactLinkedPrisonerIntegrationTest : PostgresIntegrationTestBase() {
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = prisoner1OtherRelationship.prisonerContactId,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "OTHER",
               relationshipToPrisonerDescription = "Other - Social",
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRestrictionsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactRestrictionsIntegrationTest.kt
@@ -91,7 +91,7 @@ class GetPrisonerContactRestrictionsIntegrationTest : PostgresIntegrationTestBas
       assertThat(contactId).isEqualTo(3L)
       assertThat(prisonerNumber).isEqualTo("G4793VF")
       assertThat(restrictionType).isEqualTo("PREINF")
-      assertThat(restrictionTypeDescription).isEqualTo("Previous Info")
+      assertThat(restrictionTypeDescription).isEqualTo("Previous info")
       assertThat(startDate).isEqualTo(LocalDate.of(2024, 1, 1))
       assertThat(expiryDate).isEqualTo(LocalDate.of(2024, 12, 31))
       assertThat(comments).isEqualTo("Restriction due to ongoing investigation")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsRelationshipIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/integration/resource/GetPrisonerContactsRelationshipIntegrationTest.kt
@@ -62,7 +62,7 @@ class GetPrisonerContactsRelationshipIntegrationTest : PostgresIntegrationTestBa
       contactId = 1,
       prisonerNumber = "A1234BB",
       relationshipType = "S",
-      relationshipTypeDescription = "Social/Family",
+      relationshipTypeDescription = "Social",
       relationshipToPrisonerCode = "FA",
       relationshipToPrisonerDescription = "Father",
       nextOfKin = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactLinkedPrisonersControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/ContactLinkedPrisonersControllerTest.kt
@@ -25,7 +25,7 @@ class ContactLinkedPrisonersControllerTest {
           LinkedPrisonerRelationshipDetails(
             prisonerContactId = 99,
             relationshipType = "S",
-            relationshipTypeDescription = "Social/Family",
+            relationshipTypeDescription = "Social",
             relationshipToPrisoner = "FA",
             relationshipToPrisonerDescription = "Father",
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/PrisonerContactControllerTest.kt
@@ -65,7 +65,7 @@ class PrisonerContactControllerTest {
       contactId = 2,
       prisonerNumber = "A1234BC",
       relationshipType = "S",
-      relationshipTypeDescription = "Social/Family",
+      relationshipTypeDescription = "Social",
       relationshipToPrisonerCode = "FRI",
       relationshipToPrisonerDescription = "Friend",
       nextOfKin = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/LinkedPrisonersServiceTest.kt
@@ -24,9 +24,9 @@ class LinkedPrisonersServiceTest {
     whenever(repo.findByContactIdAndActive(contactId, true)).thenReturn(
       listOf(
         // two relationships for A1234BC and one for X6789YZ
-        prisonerContactEntity(999, "A1234BC", "S", "Social/Family", "FRI", "Friend"),
+        prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend"),
         prisonerContactEntity(888, "A1234BC", "O", "Official", "LAW", "Lawyer"),
-        prisonerContactEntity(777, "X6789YZ", "S", "Social/Family", "FA", "Father"),
+        prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father"),
       ),
     )
     whenever(prisonerService.getPrisoner("A1234BC")).thenReturn(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC"))
@@ -45,7 +45,7 @@ class LinkedPrisonersServiceTest {
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = 999,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "FRI",
               relationshipToPrisonerDescription = "Friend",
             ),
@@ -68,7 +68,7 @@ class LinkedPrisonersServiceTest {
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = 777,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "FA",
               relationshipToPrisonerDescription = "Father",
             ),
@@ -86,8 +86,8 @@ class LinkedPrisonersServiceTest {
     whenever(repo.findByContactIdAndActive(contactId, true)).thenReturn(
       listOf(
         // two relationships for A1234BC and one for X6789YZ
-        prisonerContactEntity(999, "A1234BC", "S", "Social/Family", "FRI", "Friend"),
-        prisonerContactEntity(777, "X6789YZ", "S", "Social/Family", "FA", "Father"),
+        prisonerContactEntity(999, "A1234BC", "S", "Social", "FRI", "Friend"),
+        prisonerContactEntity(777, "X6789YZ", "S", "Social", "FA", "Father"),
       ),
     )
     whenever(prisonerService.getPrisoner("A1234BC")).thenReturn(prisoner(prisonerNumber = "A1234BC", firstName = "A", middleNames = "1234", lastName = "BC"))
@@ -106,7 +106,7 @@ class LinkedPrisonersServiceTest {
             LinkedPrisonerRelationshipDetails(
               prisonerContactId = 999,
               relationshipType = "S",
-              relationshipTypeDescription = "Social/Family",
+              relationshipTypeDescription = "Social",
               relationshipToPrisoner = "FRI",
               relationshipToPrisonerDescription = "Friend",
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactRelationshipServiceTest.kt
@@ -45,7 +45,7 @@ class PrisonerContactRelationshipServiceTest {
       contactId = 2,
       prisonerNumber = "A1234BC",
       relationshipType = "S",
-      relationshipTypeDescription = "Social/Family",
+      relationshipTypeDescription = "Social",
       relationshipToPrisonerCode = "FRIEND",
       relationshipToPrisonerDescription = "Friend",
       nextOfKin = false,
@@ -131,6 +131,6 @@ class PrisonerContactRelationshipServiceTest {
       currentTerm = true,
       comments = "No comments",
       relationshipType = "S",
-      relationshipTypeDescription = "Social/Family",
+      relationshipTypeDescription = "Social",
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/PrisonerContactServiceTest.kt
@@ -131,6 +131,6 @@ class PrisonerContactServiceTest {
       currentTerm = true,
       comments = "No comments",
       relationshipType = "S",
-      relationshipTypeDescription = "Social/Family",
+      relationshipTypeDescription = "Social",
     )
 }


### PR DESCRIPTION
A few reference data updates as requested by UCD team. Social contact types are now only referred to as Social instead of Social/Family and restriction descriptions case was normalised.

Also snuck in a tidy up of incorrect alias letters.