### PR TITLE
PRC-356: Deprecating the LANGUAGE, CITY, COUNTY, COUNTRY reference endpoints and service calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,34 @@ values required.
 
 or you can use the `Run API Locally` run config, which should be automatically picked up in intellij but is located in .run if you need to add it manually.
 
-## Testing GOV Notify locally
-
-To test Gov Notify emails locally, you just need to add one more variable to your `.env` file.
-
-```
-export NOTIFY_API_KEY=<gov.notify.api.key>
-```
-If you have added it correctly, you will see the log on startup with the following output:
-
-```
-Gov Notify emails are enabled
-```
-
-## contact_id and person_id sync
-To allow searching for a contact by the same id in both NOMIS and DPS we keeping contact_id in sync with NOMIS' person_id.
+## DPS and NOMIS contact_id and person_id sync
+To allow searching for a contact by the same id in both NOMIS and DPS we are keeping contact_id in sync with NOMIS' person_id.
 To prevent an overlap of IDs we are starting the DPS contact_id sequence at 20000000. 
 When we receive a new contact from NOMIS we use the person_id as the contact_id, ignoring the sequence.
-When we create a new contact in DPS we will generate a new contact_id > 20000000 and NOMIS will use the contact_id as the person_id in their database. 
+When we create a new contact in DPS we will generate a new contact_id > 20000000 and NOMIS will use the contact_id as the person_id in their database.
+The result is that contacts which originate in the DPS service will be in the person/contact ID range 2,000,000+ and those that originate in NOMIS will be in the ID range < 1,000,000.
+
+# NOMIS reference data
+
+We had originally planned that some reference data domains would be temporarily hosted in the Contacts service. 
+These were the coded values, descriptions and sort order for domains including COUNTRY, COUNTY, CITY and LANGUAGE.
+They do not really belong in the contacts (or personal relationships) domain, but they are used on addresses and to 
+specify the primary spoken language for contacts.
+
+These same coded values are used in a variety of other areas of NOMIS, for example, for prisoners, organisations, finance, ROTL and agencies.
+
+It became clear that there is much more analysis required in these areas, and some different ideas about what format addresses outside NOMIS 
+should take going forward. There are also some clear omissions and mistakes in the NOMIS data sets for language, country, county 
+and city data, but we needed to exactly match these mistakes and all.
+
+Though we have built the endpoints for some of this data, and services and data model to store and expose it, it became clear that the 
+analysis work to enrich it, is not an easy or quick task,nor was it core to our current work in extracting and managing contacts outside NOMIS.
+
+We therefore took the decision to deprecate these endpoints until such time as some of these decisions are made, and a suitable domain found
+to host a single copy of reference data, with the time to conduct proper analysis.
+
+In the interim, we have re-imported an exact copy NOMIS reference data for the values we need, and these are stored in our `reference_codes` 
+table, with an endpoint to return them by `groupName`. 
+
+For sync and migrate to operate, we needed exactly the same coded values as NOMIS in lots of areas, including organisation types, contact types, 
+employment types, phone number types, address types etc... ).  

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CityController.kt
@@ -17,6 +17,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CityService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
 @Tag(name = "Reference Data")
+@Deprecated(
+  level = DeprecationLevel.WARNING,
+  message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",
+)
 @RestController
 @RequestMapping(value = ["city-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountryController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountryController.kt
@@ -17,6 +17,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CountryService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
 @Tag(name = "Reference Data")
+@Deprecated(
+  level = DeprecationLevel.WARNING,
+  message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",
+)
 @RestController
 @RequestMapping(value = ["country-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/CountyController.kt
@@ -17,6 +17,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.CountyService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
 @Tag(name = "Reference Data")
+@Deprecated(
+  level = DeprecationLevel.WARNING,
+  message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",
+)
 @RestController
 @RequestMapping(value = ["county-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/LanguageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/resource/LanguageController.kt
@@ -17,6 +17,10 @@ import uk.gov.justice.digital.hmpps.hmppscontactsapi.service.LanguageService
 import uk.gov.justice.digital.hmpps.hmppscontactsapi.swagger.AuthApiResponses
 
 @Tag(name = "Reference Data")
+@Deprecated(
+  level = DeprecationLevel.WARNING,
+  message = "No longer used. Please use the generic endpoint /reference-codes/group/{groupCode} for all reference values",
+)
 @RestController
 @RequestMapping(value = ["language-reference"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @AuthApiResponses

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppscontactsapi/service/ContactService.kt
@@ -46,7 +46,6 @@ class ContactService(
   private val contactAddressPhoneRepository: ContactAddressPhoneRepository,
   private val contactEmailRepository: ContactEmailRepository,
   private val contactIdentityDetailsRepository: ContactIdentityDetailsRepository,
-  private val languageService: LanguageService,
   private val referenceCodeService: ReferenceCodeService,
 ) {
   companion object {
@@ -123,7 +122,10 @@ class ContactService(
     val identities = contactIdentityDetailsRepository.findByContactId(contactEntity.id()).map { it.toModel() }
 
     val languageDescription = contactEntity.languageCode?.let {
-      languageService.getLanguageByNomisCode(it).nomisDescription
+      referenceCodeService.getReferenceDataByGroupAndCode(
+        ReferenceCodeGroup.LANGUAGE,
+        it,
+      )?.description
     }
 
     val domesticStatusDescription = contactEntity.domesticStatus?.let {


### PR DESCRIPTION
This PR
* Replaces the use of language reference service calls in the contacts service with the common reference codes service.
* Deprecates the unused reference endpoints and services for CITY, COUNTY, COUNTRY and LANGUAGE.
* Adds the reasons for not using these data sets into the README file.
