### PR TITLE
PRC-181: Fix migrations

### DIFF
--- a/src/main/resources/migrations/common/R__v_contact_addresses.sql
+++ b/src/main/resources/migrations/common/R__v_contact_addresses.sql
@@ -2,7 +2,7 @@
 -- Creates a view over the contact_address and reference data tables to return a list of all addresses with descriptions
 -- for all codes.
 -- Note: the view is only dropped if the checksum of this migration changes
---
+-- Internal version to bump if you need to force recreation: 1
 DROP VIEW IF EXISTS v_contact_addresses;
 CREATE VIEW v_contact_addresses
 AS

--- a/src/main/resources/migrations/common/R__v_contact_identities.sql
+++ b/src/main/resources/migrations/common/R__v_contact_identities.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the contact_identity and reference_codes tables to return a list of all identities with descriptions
 -- for all codes.
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_contact_identities;
 CREATE VIEW v_contact_identities

--- a/src/main/resources/migrations/common/R__v_contact_phone_numbers.sql
+++ b/src/main/resources/migrations/common/R__v_contact_phone_numbers.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the contact_phone and reference_codes tables to return a list of all phone numbers with descriptions
 -- for all codes.
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_contact_phone_numbers;
 CREATE VIEW v_contact_phone_numbers

--- a/src/main/resources/migrations/common/R__v_contact_restriction_details.sql
+++ b/src/main/resources/migrations/common/R__v_contact_restriction_details.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the contact_restriction and reference data tables to return a list of contact global restrictions by
 -- contact_id
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_contact_restriction_details;
 CREATE VIEW v_contact_restriction_details

--- a/src/main/resources/migrations/common/R__v_contacts_with_primary_address.sql
+++ b/src/main/resources/migrations/common/R__v_contacts_with_primary_address.sql
@@ -3,6 +3,7 @@
 -- to return a list of active or inactive contacts, and their primary addresses,
 -- for a prisoner.
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_contacts_with_primary_address;
 CREATE VIEW v_contacts_with_primary_address

--- a/src/main/resources/migrations/common/R__v_organisation_addresses.sql
+++ b/src/main/resources/migrations/common/R__v_organisation_addresses.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the organisation_address and reference data tables to return a list of all addresses with descriptions
 -- for all codes.
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_organisation_addresses;
 CREATE VIEW v_organisation_addresses

--- a/src/main/resources/migrations/common/R__v_organisation_phone_numbers.sql
+++ b/src/main/resources/migrations/common/R__v_organisation_phone_numbers.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the organisation_phone and reference_codes tables to return a list of all phone numbers with descriptions
 -- for all codes.
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_organisation_phone_numbers;
 CREATE VIEW v_organisation_phone_numbers

--- a/src/main/resources/migrations/common/R__v_organisation_summary.sql
+++ b/src/main/resources/migrations/common/R__v_organisation_summary.sql
@@ -1,6 +1,7 @@
 --
 -- Creates a view over the organisation, organisation_address and other associated tables to create a summary of an
 -- organisation. This is intended to be used in search results and other places where only high level information is required.
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_organisation_summary;
 CREATE VIEW v_organisation_summary

--- a/src/main/resources/migrations/common/R__v_organisation_types.sql
+++ b/src/main/resources/migrations/common/R__v_organisation_types.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the organisation_type and reference_codes tables to return a list of all org types with descriptions
 -- for all codes.
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_organisation_types;
 CREATE VIEW v_organisation_types

--- a/src/main/resources/migrations/common/R__v_prisoner_contact_restriction_details.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contact_restriction_details.sql
@@ -2,6 +2,7 @@
 -- Creates a view over the prisoner_contact_restriction and reference data tables to return a list of prisoner-contact restrictions by
 -- contact_id
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_prisoner_contact_restriction_details;
 CREATE VIEW v_prisoner_contact_restriction_details

--- a/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
+++ b/src/main/resources/migrations/common/R__v_prisoner_contacts.sql
@@ -3,6 +3,7 @@
 -- to return a list of active or inactive contacts, and their primary addresses,
 -- for a prisoner, where the current_term is true (latest booking only).
 -- Note: the view is only dropped if the checksum of this migration changes
+-- Internal version to bump if you need to force recreation: 1
 --
 DROP VIEW IF EXISTS v_prisoner_contacts;
 CREATE VIEW v_prisoner_contacts

--- a/src/main/resources/migrations/common/V2025.01.24.16__alter_type_of_contact_and_org_pk_data.sql
+++ b/src/main/resources/migrations/common/V2025.01.24.16__alter_type_of_contact_and_org_pk_data.sql
@@ -1,6 +1,18 @@
 --
 -- The two were incorrectly set as integers despite being modelled as longs in Kotlin allowing integer overflow.
 --
+DROP VIEW IF EXISTS v_contact_addresses;
+DROP VIEW IF EXISTS v_contact_identities;
+DROP VIEW IF EXISTS v_contact_phone_numbers;
+DROP VIEW IF EXISTS v_contact_restriction_details;
+DROP VIEW IF EXISTS v_contacts_with_primary_address;
+DROP VIEW IF EXISTS v_organisation_addresses;
+DROP VIEW IF EXISTS v_organisation_phone_numbers;
+DROP VIEW IF EXISTS v_organisation_summary;
+DROP VIEW IF EXISTS v_organisation_types;
+DROP VIEW IF EXISTS v_prisoner_contact_restriction_details;
+DROP VIEW IF EXISTS v_prisoner_contacts;
+
 ALTER TABLE contact ALTER COLUMN contact_id TYPE BIGINT;
 ALTER TABLE organisation ALTER COLUMN organisation_id TYPE BIGINT;
 


### PR DESCRIPTION
The type of organisation and contact ids was updated which invalidates all the views but without requiring a change to the view.

Drop all the views in the faulty migration and trigger a recreation by altering the view files to force a checksum mismatch. :fingersxd: