### PR TITLE
PRC-181: Fix migrations part 2

### DIFF
--- a/src/main/resources/migrations/test/V2025.01.24.16__alter_type_of_contact_and_org_pk_data.sql
+++ b/src/main/resources/migrations/test/V2025.01.24.16__alter_type_of_contact_and_org_pk_data.sql
@@ -1,5 +1,7 @@
 --
 -- The two were incorrectly set as integers despite being modelled as longs in Kotlin allowing integer overflow.
+-- This breaks the dev environment now that there are millions of contacts so needs to be rolled into main scripts
+-- when we next wipe the db.
 --
 DROP VIEW IF EXISTS v_contact_addresses;
 DROP VIEW IF EXISTS v_contact_identities;


### PR DESCRIPTION
Moving alter type of contact and organisation to only for tests to support random long. Will roll up scripts when we split the db between contacts and organisations.